### PR TITLE
Parallel

### DIFF
--- a/.github/workflows/website_create_and_deploy.yml
+++ b/.github/workflows/website_create_and_deploy.yml
@@ -2,7 +2,7 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Create and Deploy Prod HTML site
-# Includes building automatically when either of the relavent JSON files update on the main branch or on the push of a button
+# Includes building automatically when either of the relevant JSON files update on the main branch or on the push of a button
 on:
   workflow_dispatch:
   push:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,8 @@ repos:
   rev: v0.3.5
   hooks:
     - id: ruff
+      args: ["--fix", "--show-fixes"]
+    - id: ruff-format
 
 ci:
     autofix_commit_msg: |

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -52,370 +52,6 @@ package:
     sha256: fbe2c5e56a653bebb982eda4876a9178aedfc2b545f25d0ce9c4c0b508253d22
   category: main
   optional: false
-- name: anyio
-  version: 4.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    exceptiongroup: '>=1.0.2'
-    idna: '>=2.8'
-    python: '>=3.8'
-    sniffio: '>=1.1'
-    typing_extensions: '>=4.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81ce9f3d9697b534d95118bb86c8a07e
-    sha256: 68458e31bdf3334f0e85f08767718ca9bc35bc2a79a6c503942ac99da98e510a
-  category: main
-  optional: false
-- name: anyio
-  version: 4.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    sniffio: '>=1.1'
-    typing_extensions: '>=4.1'
-    idna: '>=2.8'
-    exceptiongroup: '>=1.0.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81ce9f3d9697b534d95118bb86c8a07e
-    sha256: 68458e31bdf3334f0e85f08767718ca9bc35bc2a79a6c503942ac99da98e510a
-  category: main
-  optional: false
-- name: anyio
-  version: 4.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    sniffio: '>=1.1'
-    typing_extensions: '>=4.1'
-    idna: '>=2.8'
-    exceptiongroup: '>=1.0.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81ce9f3d9697b534d95118bb86c8a07e
-    sha256: 68458e31bdf3334f0e85f08767718ca9bc35bc2a79a6c503942ac99da98e510a
-  category: main
-  optional: false
-- name: anyio
-  version: 4.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    sniffio: '>=1.1'
-    typing_extensions: '>=4.1'
-    idna: '>=2.8'
-    exceptiongroup: '>=1.0.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/anyio-4.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81ce9f3d9697b534d95118bb86c8a07e
-    sha256: 68458e31bdf3334f0e85f08767718ca9bc35bc2a79a6c503942ac99da98e510a
-  category: main
-  optional: false
-- name: appnope
-  version: 0.1.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: cc4834a9ee7cc49ce8d25177c47b10d8
-    sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
-  category: main
-  optional: false
-- name: appnope
-  version: 0.1.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/appnope-0.1.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: cc4834a9ee7cc49ce8d25177c47b10d8
-    sha256: 45ae2d41f4a4dcf8707633d3d7ae376fc62f0c09b1d063c3049c3f6f8c911670
-  category: main
-  optional: false
-- name: argon2-cffi
-  version: 23.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    argon2-cffi-bindings: ''
-    python: '>=3.7'
-    typing-extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
-    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
-  category: main
-  optional: false
-- name: argon2-cffi
-  version: 23.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    typing-extensions: ''
-    argon2-cffi-bindings: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
-    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
-  category: main
-  optional: false
-- name: argon2-cffi
-  version: 23.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    typing-extensions: ''
-    argon2-cffi-bindings: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
-    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
-  category: main
-  optional: false
-- name: argon2-cffi
-  version: 23.1.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    typing-extensions: ''
-    argon2-cffi-bindings: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/argon2-cffi-23.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3afef1f55a1366b4d3b6a0d92e2235e4
-    sha256: 130766446f5507bd44df957b6b5c898a8bd98f024bb426ed6cb9ff1ad67fc677
-  category: main
-  optional: false
-- name: argon2-cffi-bindings
-  version: 21.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cffi: '>=1.0.1'
-    libgcc-ng: '>=12'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/argon2-cffi-bindings-21.2.0-py312h98912ed_4.conda
-  hash:
-    md5: 00536e0a1734dcde9815fe227f32fc5a
-    sha256: 8ddb4a586bc128f1b9484f82c5cb0226340527fbfe093adf3b76b7e755e11477
-  category: main
-  optional: false
-- name: argon2-cffi-bindings
-  version: 21.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    cffi: '>=1.0.1'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/argon2-cffi-bindings-21.2.0-py312h104f124_4.conda
-  hash:
-    md5: dddfb6125aed1fb84eb13319007c08fd
-    sha256: aa321e91f0ff365b5261fa1dcffa2d32aa957561bdbb38988e52e28e25a762a8
-  category: main
-  optional: false
-- name: argon2-cffi-bindings
-  version: 21.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    cffi: '>=1.0.1'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/argon2-cffi-bindings-21.2.0-py312h02f2b3b_4.conda
-  hash:
-    md5: 015edbb6fae68ab35881f55f149d4725
-    sha256: 1cfcf4b2d36a3b183a5cb1c69f85768166e50af6ced5ae381c440666a6da12c6
-  category: main
-  optional: false
-- name: argon2-cffi-bindings
-  version: 21.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    cffi: '>=1.0.1'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/argon2-cffi-bindings-21.2.0-py312he70551f_4.conda
-  hash:
-    md5: 69b7a1d899d46b91f8eecab9abf9728c
-    sha256: 4c3c428b994400ca753d9d0adbb11ce2d2a87f4dacd86c91d6cf985c5d89a3e1
-  category: main
-  optional: false
-- name: arrow
-  version: 1.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-    python-dateutil: '>=2.7.0'
-    types-python-dateutil: '>=2.8.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b77d8c2313158e6e461ca0efb1c2c508
-    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
-  category: main
-  optional: false
-- name: arrow
-  version: 1.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    python-dateutil: '>=2.7.0'
-    types-python-dateutil: '>=2.8.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b77d8c2313158e6e461ca0efb1c2c508
-    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
-  category: main
-  optional: false
-- name: arrow
-  version: 1.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    python-dateutil: '>=2.7.0'
-    types-python-dateutil: '>=2.8.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b77d8c2313158e6e461ca0efb1c2c508
-    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
-  category: main
-  optional: false
-- name: arrow
-  version: 1.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    python-dateutil: '>=2.7.0'
-    types-python-dateutil: '>=2.8.10'
-  url: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: b77d8c2313158e6e461ca0efb1c2c508
-    sha256: ff49825c7f9e29e09afa6284300810e7a8640d621740efb47c4541f4dc4969db
-  category: main
-  optional: false
-- name: asttokens
-  version: 2.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-    six: '>=1.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
-  category: main
-  optional: false
-- name: asttokens
-  version: 2.4.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-    six: '>=1.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
-  category: main
-  optional: false
-- name: asttokens
-  version: 2.4.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-    six: '>=1.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
-  category: main
-  optional: false
-- name: asttokens
-  version: 2.4.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.5'
-    six: '>=1.12.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/asttokens-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5f25798dcefd8252ce5f9dc494d5f571
-    sha256: 708168f026df19a0344983754d27d1f7b28bb21afc7b97a82f02c4798a3d2111
-  category: main
-  optional: false
-- name: async-lru
-  version: 2.0.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-    typing_extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
-    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
-  category: main
-  optional: false
-- name: async-lru
-  version: 2.0.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    typing_extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
-    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
-  category: main
-  optional: false
-- name: async-lru
-  version: 2.0.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    typing_extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
-    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
-  category: main
-  optional: false
-- name: async-lru
-  version: 2.0.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    typing_extensions: '>=4.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/async-lru-2.0.4-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3d081de3a6ea9f894bbb585e8e3a4dcb
-    sha256: 7ed83731979fe5b046c157730e50af0e24454468bbba1ed8fc1a3107db5d7518
-  category: main
-  optional: false
 - name: attrs
   version: 23.2.0
   manager: conda
@@ -1452,62 +1088,6 @@ package:
     sha256: cd3550f2181f3b62853af292d4f2639c2d1dee139f3949621173c4699aeb30da
   category: main
   optional: false
-- name: babel
-  version: 2.14.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    pytz: ''
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 9669586875baeced8fc30c0826c3270e
-    sha256: 8584e3da58e92b72641c89ff9b98c51f0d5dbe76e527867804cbdf03ac91d8e6
-  category: main
-  optional: false
-- name: babel
-  version: 2.14.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    setuptools: ''
-    pytz: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 9669586875baeced8fc30c0826c3270e
-    sha256: 8584e3da58e92b72641c89ff9b98c51f0d5dbe76e527867804cbdf03ac91d8e6
-  category: main
-  optional: false
-- name: babel
-  version: 2.14.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    setuptools: ''
-    pytz: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 9669586875baeced8fc30c0826c3270e
-    sha256: 8584e3da58e92b72641c89ff9b98c51f0d5dbe76e527867804cbdf03ac91d8e6
-  category: main
-  optional: false
-- name: babel
-  version: 2.14.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    setuptools: ''
-    pytz: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/babel-2.14.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 9669586875baeced8fc30c0826c3270e
-    sha256: 8584e3da58e92b72641c89ff9b98c51f0d5dbe76e527867804cbdf03ac91d8e6
-  category: main
-  optional: false
 - name: beautifulsoup4
   version: 4.12.3
   manager: conda
@@ -1558,70 +1138,6 @@ package:
   hash:
     md5: 332493000404d8411859539a5a630865
     sha256: 7b05b2d0669029326c623b9df7a29fa49d1982a9e7e31b2fea34b4c9a4a72317
-  category: main
-  optional: false
-- name: bleach
-  version: 6.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    packaging: ''
-    python: '>=3.6'
-    setuptools: ''
-    six: '>=1.9.0'
-    webencodings: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
-    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
-  category: main
-  optional: false
-- name: bleach
-  version: 6.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    setuptools: ''
-    packaging: ''
-    webencodings: ''
-    python: '>=3.6'
-    six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
-    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
-  category: main
-  optional: false
-- name: bleach
-  version: 6.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    setuptools: ''
-    packaging: ''
-    webencodings: ''
-    python: '>=3.6'
-    six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
-    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
-  category: main
-  optional: false
-- name: bleach
-  version: 6.1.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    setuptools: ''
-    packaging: ''
-    webencodings: ''
-    python: '>=3.6'
-    six: '>=1.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/bleach-6.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0ed9d7c0e9afa7c025807a9a8136ea3e
-    sha256: 845e77ef495376c5c3c328ccfd746ca0ef1978150cae8eae61a300fe7755fb08
   category: main
   optional: false
 - name: blosc
@@ -2104,102 +1620,6 @@ package:
   hash:
     md5: 63da060240ab8087b60d1357051ea7d6
     sha256: 4d587088ecccd393fec3420b64f1af4ee1a0e6897a45cfd5ef38055322cea5d0
-  category: main
-  optional: false
-- name: cached-property
-  version: 1.5.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cached_property: '>=1.5.2,<1.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-  hash:
-    md5: 9b347a7ec10940d3f7941ff6c460b551
-    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
-  category: main
-  optional: false
-- name: cached-property
-  version: 1.5.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    cached_property: '>=1.5.2,<1.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-  hash:
-    md5: 9b347a7ec10940d3f7941ff6c460b551
-    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
-  category: main
-  optional: false
-- name: cached-property
-  version: 1.5.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    cached_property: '>=1.5.2,<1.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-  hash:
-    md5: 9b347a7ec10940d3f7941ff6c460b551
-    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
-  category: main
-  optional: false
-- name: cached-property
-  version: 1.5.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    cached_property: '>=1.5.2,<1.5.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached-property-1.5.2-hd8ed1ab_1.tar.bz2
-  hash:
-    md5: 9b347a7ec10940d3f7941ff6c460b551
-    sha256: 561e6660f26c35d137ee150187d89767c988413c978e1b712d53f27ddf70ea17
-  category: main
-  optional: false
-- name: cached_property
-  version: 1.5.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-  hash:
-    md5: 576d629e47797577ab0f1b351297ef4a
-    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
-  category: main
-  optional: false
-- name: cached_property
-  version: 1.5.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-  hash:
-    md5: 576d629e47797577ab0f1b351297ef4a
-    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
-  category: main
-  optional: false
-- name: cached_property
-  version: 1.5.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-  hash:
-    md5: 576d629e47797577ab0f1b351297ef4a
-    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
-  category: main
-  optional: false
-- name: cached_property
-  version: 1.5.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/cached_property-1.5.2-pyha770c72_1.tar.bz2
-  hash:
-    md5: 576d629e47797577ab0f1b351297ef4a
-    sha256: 6dbf7a5070cc43d90a1e4c2ec0c541c69d8e30a0e25f50ce9f6e4a432e42c5d7
   category: main
   optional: false
 - name: cairo
@@ -2794,58 +2214,6 @@ package:
     sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
   category: main
   optional: false
-- name: comm
-  version: 0.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: f4385072f4909bc974f6675a36e76796
-    sha256: bd90a200e6f7092a89f02c4800729a4a6d2b2de49d70a9706aeb083a635308c1
-  category: main
-  optional: false
-- name: comm
-  version: 0.2.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: f4385072f4909bc974f6675a36e76796
-    sha256: bd90a200e6f7092a89f02c4800729a4a6d2b2de49d70a9706aeb083a635308c1
-  category: main
-  optional: false
-- name: comm
-  version: 0.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: f4385072f4909bc974f6675a36e76796
-    sha256: bd90a200e6f7092a89f02c4800729a4a6d2b2de49d70a9706aeb083a635308c1
-  category: main
-  optional: false
-- name: comm
-  version: 0.2.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/comm-0.2.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: f4385072f4909bc974f6675a36e76796
-    sha256: bd90a200e6f7092a89f02c4800729a4a6d2b2de49d70a9706aeb083a635308c1
-  category: main
-  optional: false
 - name: contourpy
   version: 1.2.0
   manager: conda
@@ -3029,6 +2397,7 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
+    cffi: '>=1.12'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     python: '>=3.12,<3.13.0a0'
@@ -3083,97 +2452,97 @@ package:
     sha256: 5e8beecf42088481c88aa97118c52b2142f0e0d48ffed877e973c309c7fc83af
   category: main
   optional: false
-- name: decorator
-  version: 5.1.1
+- name: cycler
+  version: 0.12.1
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+    md5: 5cd86562580f274031ede6aa6aa24441
+    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   category: main
   optional: false
-- name: decorator
-  version: 5.1.1
+- name: cycler
+  version: 0.12.1
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+    md5: 5cd86562580f274031ede6aa6aa24441
+    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   category: main
   optional: false
-- name: decorator
-  version: 5.1.1
+- name: cycler
+  version: 0.12.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+    md5: 5cd86562580f274031ede6aa6aa24441
+    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   category: main
   optional: false
-- name: decorator
-  version: 5.1.1
+- name: cycler
+  version: 0.12.1
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/decorator-5.1.1-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 43afe5ab04e35e17ba28649471dd7364
-    sha256: 328a6a379f9bdfd0230e51de291ce858e6479411ea4b0545fb377c71662ef3e2
+    md5: 5cd86562580f274031ede6aa6aa24441
+    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   category: main
   optional: false
-- name: defusedxml
-  version: 0.7.1
+- name: docopt
+  version: 0.6.2
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
   hash:
-    md5: 961b3a227b437d82ad7054484cfa71b2
-    sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+    md5: a9ed63e45579cfef026a916af2bc27c9
+    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
   category: main
   optional: false
-- name: defusedxml
-  version: 0.7.1
+- name: docopt
+  version: 0.6.2
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
   hash:
-    md5: 961b3a227b437d82ad7054484cfa71b2
-    sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+    md5: a9ed63e45579cfef026a916af2bc27c9
+    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
   category: main
   optional: false
-- name: defusedxml
-  version: 0.7.1
+- name: docopt
+  version: 0.6.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
   hash:
-    md5: 961b3a227b437d82ad7054484cfa71b2
-    sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
+    md5: a9ed63e45579cfef026a916af2bc27c9
+    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
   category: main
   optional: false
-- name: defusedxml
-  version: 0.7.1
+- name: docopt
+  version: 0.6.2
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/defusedxml-0.7.1-pyhd8ed1ab_0.tar.bz2
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
   hash:
     md5: 961b3a227b437d82ad7054484cfa71b2
     sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
@@ -3404,54 +2773,6 @@ package:
     sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
   category: main
   optional: false
-- name: executing
-  version: 2.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
-  category: main
-  optional: false
-- name: executing
-  version: 2.0.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
-  category: main
-  optional: false
-- name: executing
-  version: 2.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
-  category: main
-  optional: false
-- name: executing
-  version: 2.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=2.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/executing-2.0.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: e16be50e378d8a4533b989035b196ab8
-    sha256: c738804ab1e6376f8ea63372229a04c8d658dc90fd5a218c6273a2eaf02f4057
-  category: main
-  optional: false
 - name: expat
   version: 2.5.0
   manager: conda
@@ -3555,46 +2876,46 @@ package:
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/findlibs-0.0.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fake-useragent-1.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 8f325f63020af6f7acbe2c4cb4c920db
-    sha256: d6baa0cdab78f07f38d62a926c3c046f9e07493b261d123b4c2971ac73178684
+    md5: 87ac838f10c54be8014803165f44b936
+    sha256: 3710af40b8d780a0ee3884340662f67c4ccd67295a536113133181a680b3e551
   category: main
   optional: false
-- name: findlibs
-  version: 0.0.5
+- name: fake-useragent
+  version: 1.4.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/findlibs-0.0.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fake-useragent-1.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 8f325f63020af6f7acbe2c4cb4c920db
-    sha256: d6baa0cdab78f07f38d62a926c3c046f9e07493b261d123b4c2971ac73178684
+    md5: 87ac838f10c54be8014803165f44b936
+    sha256: 3710af40b8d780a0ee3884340662f67c4ccd67295a536113133181a680b3e551
   category: main
   optional: false
-- name: findlibs
-  version: 0.0.5
+- name: fake-useragent
+  version: 1.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/findlibs-0.0.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fake-useragent-1.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 8f325f63020af6f7acbe2c4cb4c920db
-    sha256: d6baa0cdab78f07f38d62a926c3c046f9e07493b261d123b4c2971ac73178684
+    md5: 87ac838f10c54be8014803165f44b936
+    sha256: 3710af40b8d780a0ee3884340662f67c4ccd67295a536113133181a680b3e551
   category: main
   optional: false
-- name: findlibs
-  version: 0.0.5
+- name: fake-useragent
+  version: 1.4.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/findlibs-0.0.5-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/fake-useragent-1.4.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 8f325f63020af6f7acbe2c4cb4c920db
-    sha256: d6baa0cdab78f07f38d62a926c3c046f9e07493b261d123b4c2971ac73178684
+    md5: 87ac838f10c54be8014803165f44b936
+    sha256: 3710af40b8d780a0ee3884340662f67c4ccd67295a536113133181a680b3e551
   category: main
   optional: false
 - name: fiona
@@ -3694,54 +3015,6 @@ package:
   hash:
     md5: e6cba0c3b00e5d6cb0ddf7146806c38b
     sha256: 5522d5c92740105a0a0a0c58b366845ca0b1822bd3b28e184862d7403597a8a9
-  category: main
-  optional: false
-- name: fiscalyear
-  version: 0.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/fiscalyear-0.4.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 863f50923bfca4bea3692769c2f3345e
-    sha256: 3aec78b79433c1c55f14f7da07446b95d782d5ebc6741540dc834be7552c3bd1
-  category: main
-  optional: false
-- name: fiscalyear
-  version: 0.4.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/fiscalyear-0.4.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 863f50923bfca4bea3692769c2f3345e
-    sha256: 3aec78b79433c1c55f14f7da07446b95d782d5ebc6741540dc834be7552c3bd1
-  category: main
-  optional: false
-- name: fiscalyear
-  version: 0.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/fiscalyear-0.4.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 863f50923bfca4bea3692769c2f3345e
-    sha256: 3aec78b79433c1c55f14f7da07446b95d782d5ebc6741540dc834be7552c3bd1
-  category: main
-  optional: false
-- name: fiscalyear
-  version: 0.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/fiscalyear-0.4.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 863f50923bfca4bea3692769c2f3345e
-    sha256: 3aec78b79433c1c55f14f7da07446b95d782d5ebc6741540dc834be7552c3bd1
   category: main
   optional: false
 - name: folium
@@ -4220,91 +3493,6 @@ package:
   hash:
     md5: 19208b0c0f867d08ea95a334810193a1
     sha256: 8ab968251cd063b00d92b6a2172861ec6b44d4ac03a50218bf6e8531358cfad7
-  category: main
-  optional: false
-- name: fqdn
-  version: 1.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    cached-property: '>=1.3.0'
-    python: '>=2.7,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 642d35437078749ef23a5dca2c9bb1f3
-    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
-  category: main
-  optional: false
-- name: fqdn
-  version: 1.5.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    cached-property: '>=1.3.0'
-    python: '>=2.7,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 642d35437078749ef23a5dca2c9bb1f3
-    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
-  category: main
-  optional: false
-- name: fqdn
-  version: 1.5.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    cached-property: '>=1.3.0'
-    python: '>=2.7,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 642d35437078749ef23a5dca2c9bb1f3
-    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
-  category: main
-  optional: false
-- name: fqdn
-  version: 1.5.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    cached-property: '>=1.3.0'
-    python: '>=2.7,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/fqdn-1.5.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 642d35437078749ef23a5dca2c9bb1f3
-    sha256: 6cfd1f9bcd2358a69fb571f4b3af049b630d52647d906822dbedac03e84e4f63
-  category: main
-  optional: false
-- name: freeglut
-  version: 3.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    xorg-libx11: '>=1.8.4,<2.0a0'
-    xorg-libxau: '>=1.0.11,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-libxfixes: ''
-    xorg-libxi: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/freeglut-3.2.2-hac7e632_2.conda
-  hash:
-    md5: 6e553df297f6e64668efb54302e0f139
-    sha256: 6dc7be5d0853ea5bcbb2b1921baf7d069605594c207e8ce36a662f447cd81a3f
-  category: main
-  optional: false
-- name: freeglut
-  version: 3.2.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/freeglut-3.2.2-h63175ca_2.conda
-  hash:
-    md5: e2d290a0159d485932abed83878e6952
-    sha256: 42fd40d97dab1adb63ff0bb001e4ed9b3eef377a2de5e572bf989c6db79262c8
   category: main
   optional: false
 - name: freetype
@@ -5169,238 +4357,6 @@ package:
     sha256: 89bbb2c878e1b6c6073ef5f1f25eac97ed48393541a4a44a7d182da5ede3dc98
   category: main
   optional: false
-- name: hpack
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 914d6646c4dbb1fd3ff539830a12fd71
-    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
-  category: main
-  optional: false
-- name: hpack
-  version: 4.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 914d6646c4dbb1fd3ff539830a12fd71
-    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
-  category: main
-  optional: false
-- name: hpack
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 914d6646c4dbb1fd3ff539830a12fd71
-    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
-  category: main
-  optional: false
-- name: hpack
-  version: 4.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 914d6646c4dbb1fd3ff539830a12fd71
-    sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
-  category: main
-  optional: false
-- name: httpcore
-  version: 1.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    anyio: '>=3.0,<5.0'
-    certifi: ''
-    h11: '>=0.13,<0.15'
-    h2: '>=3,<5'
-    python: '>=3.8'
-    sniffio: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 48995b2157996a94f50fa483d884e0a3
-    sha256: b9a2ec0ecdaf54d67caf73d8a94c8ddba62f482093a5adbfb89c2ce020d64475
-  category: main
-  optional: false
-- name: httpcore
-  version: 1.0.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    certifi: ''
-    python: '>=3.8'
-    sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 48995b2157996a94f50fa483d884e0a3
-    sha256: b9a2ec0ecdaf54d67caf73d8a94c8ddba62f482093a5adbfb89c2ce020d64475
-  category: main
-  optional: false
-- name: httpcore
-  version: 1.0.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    certifi: ''
-    python: '>=3.8'
-    sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 48995b2157996a94f50fa483d884e0a3
-    sha256: b9a2ec0ecdaf54d67caf73d8a94c8ddba62f482093a5adbfb89c2ce020d64475
-  category: main
-  optional: false
-- name: httpcore
-  version: 1.0.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    certifi: ''
-    python: '>=3.8'
-    sniffio: 1.*
-    h2: '>=3,<5'
-    anyio: '>=3.0,<5.0'
-    h11: '>=0.13,<0.15'
-  url: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 48995b2157996a94f50fa483d884e0a3
-    sha256: b9a2ec0ecdaf54d67caf73d8a94c8ddba62f482093a5adbfb89c2ce020d64475
-  category: main
-  optional: false
-- name: httpx
-  version: 0.26.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    anyio: ''
-    certifi: ''
-    httpcore: 1.*
-    idna: ''
-    python: '>=3.8'
-    sniffio: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.26.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0faecf87c2b27f5cde5ef45528ad2a6c
-    sha256: 7ed1c5eaa6fef7aa0047feb6d66b05b2b1137422722f752c0de990c7b7ff5260
-  category: main
-  optional: false
-- name: httpx
-  version: 0.26.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    certifi: ''
-    idna: ''
-    anyio: ''
-    sniffio: ''
-    python: '>=3.8'
-    httpcore: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.26.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0faecf87c2b27f5cde5ef45528ad2a6c
-    sha256: 7ed1c5eaa6fef7aa0047feb6d66b05b2b1137422722f752c0de990c7b7ff5260
-  category: main
-  optional: false
-- name: httpx
-  version: 0.26.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    certifi: ''
-    idna: ''
-    anyio: ''
-    sniffio: ''
-    python: '>=3.8'
-    httpcore: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.26.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0faecf87c2b27f5cde5ef45528ad2a6c
-    sha256: 7ed1c5eaa6fef7aa0047feb6d66b05b2b1137422722f752c0de990c7b7ff5260
-  category: main
-  optional: false
-- name: httpx
-  version: 0.26.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    certifi: ''
-    idna: ''
-    anyio: ''
-    sniffio: ''
-    python: '>=3.8'
-    httpcore: 1.*
-  url: https://conda.anaconda.org/conda-forge/noarch/httpx-0.26.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0faecf87c2b27f5cde5ef45528ad2a6c
-    sha256: 7ed1c5eaa6fef7aa0047feb6d66b05b2b1137422722f752c0de990c7b7ff5260
-  category: main
-  optional: false
-- name: hyperframe
-  version: 6.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9f765cbfab6870c8435b9eefecd7a1f4
-    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
-  category: main
-  optional: false
-- name: hyperframe
-  version: 6.0.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9f765cbfab6870c8435b9eefecd7a1f4
-    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
-  category: main
-  optional: false
-- name: hyperframe
-  version: 6.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9f765cbfab6870c8435b9eefecd7a1f4
-    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
-  category: main
-  optional: false
-- name: hyperframe
-  version: 6.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 9f765cbfab6870c8435b9eefecd7a1f4
-    sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
-  category: main
-  optional: false
 - name: icu
   version: '73.2'
   manager: conda
@@ -5496,158 +4452,6 @@ package:
   hash:
     md5: 1a76f09108576397c41c0b0c5bd84134
     sha256: 6ee4c986d69ce61e60a20b2459b6f2027baeba153f0a64995fd3cb47c2cc7e07
-  category: main
-  optional: false
-- name: importlib-metadata
-  version: 7.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.1-pyha770c72_0.conda
-  hash:
-    md5: 746623a787e06191d80a2133e5daff17
-    sha256: e72d05f171f4567004c9360a838e9d5df21e23dcfeb945066b53a6e5f754b861
-  category: main
-  optional: false
-- name: importlib-metadata
-  version: 7.0.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.1-pyha770c72_0.conda
-  hash:
-    md5: 746623a787e06191d80a2133e5daff17
-    sha256: e72d05f171f4567004c9360a838e9d5df21e23dcfeb945066b53a6e5f754b861
-  category: main
-  optional: false
-- name: importlib-metadata
-  version: 7.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.1-pyha770c72_0.conda
-  hash:
-    md5: 746623a787e06191d80a2133e5daff17
-    sha256: e72d05f171f4567004c9360a838e9d5df21e23dcfeb945066b53a6e5f754b861
-  category: main
-  optional: false
-- name: importlib-metadata
-  version: 7.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-7.0.1-pyha770c72_0.conda
-  hash:
-    md5: 746623a787e06191d80a2133e5daff17
-    sha256: e72d05f171f4567004c9360a838e9d5df21e23dcfeb945066b53a6e5f754b861
-  category: main
-  optional: false
-- name: importlib_metadata
-  version: 7.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib-metadata: '>=7.0.1,<7.0.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.0.1-hd8ed1ab_0.conda
-  hash:
-    md5: 4a2f43a20fa404b998859c6a470ba316
-    sha256: bc362df1d4f5a04c38dff29cd9c2d0ac584f9c4b45d3e4683ee090944a38fba4
-  category: main
-  optional: false
-- name: importlib_metadata
-  version: 7.0.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    importlib-metadata: '>=7.0.1,<7.0.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.0.1-hd8ed1ab_0.conda
-  hash:
-    md5: 4a2f43a20fa404b998859c6a470ba316
-    sha256: bc362df1d4f5a04c38dff29cd9c2d0ac584f9c4b45d3e4683ee090944a38fba4
-  category: main
-  optional: false
-- name: importlib_metadata
-  version: 7.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    importlib-metadata: '>=7.0.1,<7.0.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.0.1-hd8ed1ab_0.conda
-  hash:
-    md5: 4a2f43a20fa404b998859c6a470ba316
-    sha256: bc362df1d4f5a04c38dff29cd9c2d0ac584f9c4b45d3e4683ee090944a38fba4
-  category: main
-  optional: false
-- name: importlib_metadata
-  version: 7.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    importlib-metadata: '>=7.0.1,<7.0.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_metadata-7.0.1-hd8ed1ab_0.conda
-  hash:
-    md5: 4a2f43a20fa404b998859c6a470ba316
-    sha256: bc362df1d4f5a04c38dff29cd9c2d0ac584f9c4b45d3e4683ee090944a38fba4
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 6.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3d5fa25cf42f3f32a12b2d874ace8574
-    sha256: e584f9ae08fb2d242af0ce7e19e3cd2f85f362d8523119e08f99edb962db99ed
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 6.1.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3d5fa25cf42f3f32a12b2d874ace8574
-    sha256: e584f9ae08fb2d242af0ce7e19e3cd2f85f362d8523119e08f99edb962db99ed
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 6.1.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3d5fa25cf42f3f32a12b2d874ace8574
-    sha256: e584f9ae08fb2d242af0ce7e19e3cd2f85f362d8523119e08f99edb962db99ed
-  category: main
-  optional: false
-- name: importlib_resources
-  version: 6.1.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    zipp: '>=3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/importlib_resources-6.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 3d5fa25cf42f3f32a12b2d874ace8574
-    sha256: e584f9ae08fb2d242af0ce7e19e3cd2f85f362d8523119e08f99edb962db99ed
   category: main
   optional: false
 - name: iniconfig
@@ -9521,23 +8325,6 @@ package:
     sha256: 33527a11321609064c649682e709ebede86e24f1264dac1d018aaa00fb3b90bf
   category: main
   optional: false
-- name: libglu
-  version: 9.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    libxcb: '>=1.15,<1.16.0a0'
-    xorg-libx11: '>=1.8.6,<2.0a0'
-    xorg-libxext: '>=1.3.4,<2.0a0'
-    xorg-xextproto: '>=7.3.0,<8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglu-9.0.0-hac7e632_1003.conda
-  hash:
-    md5: 50c389a09b6b7babaef531eb7cb5e0ca
-    sha256: 8368435c41105dc3e1c02896a02ecaa21b77d0b0d67fc8b06a16ba885c86f917
-  category: main
-  optional: false
 - name: libgomp
   version: 13.2.0
   manager: conda
@@ -10550,53 +9337,6 @@ package:
   hash:
     md5: 3c2a870012ae8f6ffcc7735715f197b1
     sha256: 1a85091ebed8272b0c9b9e5aacba1d423c6411bfa91d7777c1ede8c7a42c933b
-  category: main
-  optional: false
-- name: libsodium
-  version: 1.0.18
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsodium-1.0.18-h36c2ea0_1.tar.bz2
-  hash:
-    md5: c3788462a6fbddafdb413a9f9053e58d
-    sha256: 53da0c8b79659df7b53eebdb80783503ce72fb4b10ed6e9e05cc0e9e4207a130
-  category: main
-  optional: false
-- name: libsodium
-  version: 1.0.18
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsodium-1.0.18-hbcb3906_1.tar.bz2
-  hash:
-    md5: 24632c09ed931af617fe6d5292919cab
-    sha256: 2da45f14e3d383b4b9e3a8bacc95cd2832aac2dbf9fbc70d255d384a310c5660
-  category: main
-  optional: false
-- name: libsodium
-  version: 1.0.18
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsodium-1.0.18-h27ca646_1.tar.bz2
-  hash:
-    md5: 90859688dbca4735b74c02af14c4c793
-    sha256: 1d95fe5e5e6a0700669aab454b2a32f97289c9ed8d1f7667c2ba98327a6f05bc
-  category: main
-  optional: false
-- name: libsodium
-  version: 1.0.18
-  manager: conda
-  platform: win-64
-  dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
-  url: https://conda.anaconda.org/conda-forge/win-64/libsodium-1.0.18-h8d14728_1.tar.bz2
-  hash:
-    md5: 5c1fb45b5e2912c19098750ae8a32604
-    sha256: ecc463f0ab6eaf6bc5bd6ff9c17f65595de6c7a38db812222ab8ffde0d3f4bc2
   category: main
   optional: false
 - name: libspatialindex
@@ -11885,58 +10625,6 @@ package:
     sha256: 997faaf5c50cd544f2eb65ae461189e078bc3d5ff1df008ee69fad46f4215f84
   category: main
   optional: false
-- name: matplotlib-inline
-  version: 0.1.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21613793fcc81d944c76c9f2864a7de
-    sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-  category: main
-  optional: false
-- name: matplotlib-inline
-  version: 0.1.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    traitlets: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21613793fcc81d944c76c9f2864a7de
-    sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-  category: main
-  optional: false
-- name: matplotlib-inline
-  version: 0.1.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    traitlets: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21613793fcc81d944c76c9f2864a7de
-    sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-  category: main
-  optional: false
-- name: matplotlib-inline
-  version: 0.1.6
-  manager: conda
-  platform: win-64
-  dependencies:
-    traitlets: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/matplotlib-inline-0.1.6-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21613793fcc81d944c76c9f2864a7de
-    sha256: aa091b88aec55bfa2d9207028d8cdc689b9efb090ae27b99557e93c675be2f3c
-  category: main
-  optional: false
 - name: minizip
   version: 4.0.4
   manager: conda
@@ -12008,54 +10696,6 @@ package:
   hash:
     md5: 26363ae28ac1928dcf846b4d68d5f29f
     sha256: d9073fe4159263314b25f436b99ee0ebedad12fbf518937761089a5ff17259f5
-  category: main
-  optional: false
-- name: mistune
-  version: 3.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cbee699846772cc939bef23a0d524ed
-    sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
-  category: main
-  optional: false
-- name: mistune
-  version: 3.0.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cbee699846772cc939bef23a0d524ed
-    sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
-  category: main
-  optional: false
-- name: mistune
-  version: 3.0.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cbee699846772cc939bef23a0d524ed
-    sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
-  category: main
-  optional: false
-- name: mistune
-  version: 3.0.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/mistune-3.0.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cbee699846772cc939bef23a0d524ed
-    sha256: f95cb70007e3cc2ba44e17c29a056b499e6dadf08746706d0c817c8e2f47e05c
   category: main
   optional: false
 - name: mkl
@@ -12130,358 +10770,6 @@ package:
     sha256: f86fb22b58e93d04b6f25e0d811b56797689d598788b59dcb47f59045b568306
   category: main
   optional: false
-- name: nbclient
-  version: 0.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    nbformat: '>=5.1'
-    python: '>=3.8'
-    traitlets: '>=5.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e78da91cf428faaf05701ce8cc8f2f9b
-    sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
-  category: main
-  optional: false
-- name: nbclient
-  version: 0.8.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    nbformat: '>=5.1'
-    traitlets: '>=5.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e78da91cf428faaf05701ce8cc8f2f9b
-    sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
-  category: main
-  optional: false
-- name: nbclient
-  version: 0.8.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    nbformat: '>=5.1'
-    traitlets: '>=5.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e78da91cf428faaf05701ce8cc8f2f9b
-    sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
-  category: main
-  optional: false
-- name: nbclient
-  version: 0.8.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    nbformat: '>=5.1'
-    traitlets: '>=5.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbclient-0.8.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: e78da91cf428faaf05701ce8cc8f2f9b
-    sha256: 4ebd237cdf4bfa5226f92d2ae78fab8dba27696909391884dc6594ca6f9df5ff
-  category: main
-  optional: false
-- name: nbconvert
-  version: 7.16.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    nbconvert-core: 7.16.0
-    nbconvert-pandoc: 7.16.0
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 342ba1099325da21a811e80397006461
-    sha256: b1e9941abc76be0dc2666f86791445a114fafd8e680c668c53e4a93b8bef9ea3
-  category: main
-  optional: false
-- name: nbconvert
-  version: 7.16.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    nbconvert-core: 7.16.0
-    nbconvert-pandoc: 7.16.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 342ba1099325da21a811e80397006461
-    sha256: b1e9941abc76be0dc2666f86791445a114fafd8e680c668c53e4a93b8bef9ea3
-  category: main
-  optional: false
-- name: nbconvert
-  version: 7.16.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    nbconvert-core: 7.16.0
-    nbconvert-pandoc: 7.16.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 342ba1099325da21a811e80397006461
-    sha256: b1e9941abc76be0dc2666f86791445a114fafd8e680c668c53e4a93b8bef9ea3
-  category: main
-  optional: false
-- name: nbconvert
-  version: 7.16.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    nbconvert-core: 7.16.0
-    nbconvert-pandoc: 7.16.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 342ba1099325da21a811e80397006461
-    sha256: b1e9941abc76be0dc2666f86791445a114fafd8e680c668c53e4a93b8bef9ea3
-  category: main
-  optional: false
-- name: nbconvert-core
-  version: 7.16.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    beautifulsoup4: ''
-    bleach: ''
-    defusedxml: ''
-    entrypoints: '>=0.2.2'
-    jinja2: '>=3.0'
-    jupyter_core: '>=4.7'
-    jupyterlab_pygments: ''
-    markupsafe: '>=2.0'
-    mistune: '>=2.0.3,<4'
-    nbclient: '>=0.5.0'
-    nbformat: '>=5.1'
-    packaging: ''
-    pandocfilters: '>=1.4.1'
-    pygments: '>=2.4.1'
-    python: '>=3.8'
-    tinycss2: ''
-    traitlets: '>=5.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: de2255e7a38fad6eaf457739c6599413
-    sha256: 8ff53ffc16dd13dc6288ddb4d36f055e782b8f7599d832c20dec182f609d37a5
-  category: main
-  optional: false
-- name: nbconvert-core
-  version: 7.16.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    packaging: ''
-    beautifulsoup4: ''
-    defusedxml: ''
-    bleach: ''
-    tinycss2: ''
-    jupyterlab_pygments: ''
-    python: '>=3.8'
-    jinja2: '>=3.0'
-    entrypoints: '>=0.2.2'
-    jupyter_core: '>=4.7'
-    traitlets: '>=5.0'
-    markupsafe: '>=2.0'
-    pandocfilters: '>=1.4.1'
-    nbformat: '>=5.1'
-    pygments: '>=2.4.1'
-    nbclient: '>=0.5.0'
-    mistune: '>=2.0.3,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: de2255e7a38fad6eaf457739c6599413
-    sha256: 8ff53ffc16dd13dc6288ddb4d36f055e782b8f7599d832c20dec182f609d37a5
-  category: main
-  optional: false
-- name: nbconvert-core
-  version: 7.16.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    packaging: ''
-    beautifulsoup4: ''
-    defusedxml: ''
-    bleach: ''
-    tinycss2: ''
-    jupyterlab_pygments: ''
-    python: '>=3.8'
-    jinja2: '>=3.0'
-    entrypoints: '>=0.2.2'
-    jupyter_core: '>=4.7'
-    traitlets: '>=5.0'
-    markupsafe: '>=2.0'
-    pandocfilters: '>=1.4.1'
-    nbformat: '>=5.1'
-    pygments: '>=2.4.1'
-    nbclient: '>=0.5.0'
-    mistune: '>=2.0.3,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: de2255e7a38fad6eaf457739c6599413
-    sha256: 8ff53ffc16dd13dc6288ddb4d36f055e782b8f7599d832c20dec182f609d37a5
-  category: main
-  optional: false
-- name: nbconvert-core
-  version: 7.16.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    packaging: ''
-    beautifulsoup4: ''
-    defusedxml: ''
-    bleach: ''
-    tinycss2: ''
-    jupyterlab_pygments: ''
-    python: '>=3.8'
-    jinja2: '>=3.0'
-    entrypoints: '>=0.2.2'
-    jupyter_core: '>=4.7'
-    traitlets: '>=5.0'
-    markupsafe: '>=2.0'
-    pandocfilters: '>=1.4.1'
-    nbformat: '>=5.1'
-    pygments: '>=2.4.1'
-    nbclient: '>=0.5.0'
-    mistune: '>=2.0.3,<4'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-core-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: de2255e7a38fad6eaf457739c6599413
-    sha256: 8ff53ffc16dd13dc6288ddb4d36f055e782b8f7599d832c20dec182f609d37a5
-  category: main
-  optional: false
-- name: nbconvert-pandoc
-  version: 7.16.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    nbconvert-core: 7.16.0
-    pandoc: ''
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 28dde45c295b3f110bc6bb425472137b
-    sha256: 98e65344c3640523d8ae2df65884df661f545359047d5141d6ede5a463d599f3
-  category: main
-  optional: false
-- name: nbconvert-pandoc
-  version: 7.16.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    pandoc: ''
-    python: '>=3.8'
-    nbconvert-core: 7.16.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 28dde45c295b3f110bc6bb425472137b
-    sha256: 98e65344c3640523d8ae2df65884df661f545359047d5141d6ede5a463d599f3
-  category: main
-  optional: false
-- name: nbconvert-pandoc
-  version: 7.16.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    pandoc: ''
-    python: '>=3.8'
-    nbconvert-core: 7.16.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 28dde45c295b3f110bc6bb425472137b
-    sha256: 98e65344c3640523d8ae2df65884df661f545359047d5141d6ede5a463d599f3
-  category: main
-  optional: false
-- name: nbconvert-pandoc
-  version: 7.16.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    pandoc: ''
-    python: '>=3.8'
-    nbconvert-core: 7.16.0
-  url: https://conda.anaconda.org/conda-forge/noarch/nbconvert-pandoc-7.16.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 28dde45c295b3f110bc6bb425472137b
-    sha256: 98e65344c3640523d8ae2df65884df661f545359047d5141d6ede5a463d599f3
-  category: main
-  optional: false
-- name: nbformat
-  version: 5.9.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    jsonschema: '>=2.6'
-    jupyter_core: ''
-    python: '>=3.8'
-    python-fastjsonschema: ''
-    traitlets: '>=5.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 61ba076de6530d9301a0053b02f093d2
-    sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
-  category: main
-  optional: false
-- name: nbformat
-  version: 5.9.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    jupyter_core: ''
-    python-fastjsonschema: ''
-    python: '>=3.8'
-    traitlets: '>=5.1'
-    jsonschema: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 61ba076de6530d9301a0053b02f093d2
-    sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
-  category: main
-  optional: false
-- name: nbformat
-  version: 5.9.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    jupyter_core: ''
-    python-fastjsonschema: ''
-    python: '>=3.8'
-    traitlets: '>=5.1'
-    jsonschema: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 61ba076de6530d9301a0053b02f093d2
-    sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
-  category: main
-  optional: false
-- name: nbformat
-  version: 5.9.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    jupyter_core: ''
-    python-fastjsonschema: ''
-    python: '>=3.8'
-    traitlets: '>=5.1'
-    jsonschema: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/nbformat-5.9.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 61ba076de6530d9301a0053b02f093d2
-    sha256: fc82c5a9116820757b03ffb836b36f0f50e4cd390018024dbadb0ee0217f6992
-  category: main
-  optional: false
 - name: ncurses
   version: '6.4'
   manager: conda
@@ -12516,54 +10804,6 @@ package:
   hash:
     md5: 52b6f254a7b9663e854f44b6570ed982
     sha256: f6890634f815e8408d08f36503353f8dfd7b055e4c3b9ea2ee52180255cf4b0a
-  category: main
-  optional: false
-- name: nest-asyncio
-  version: 1.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6598c056f64dc8800d40add25e4e2c34
-    sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
-  category: main
-  optional: false
-- name: nest-asyncio
-  version: 1.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6598c056f64dc8800d40add25e4e2c34
-    sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
-  category: main
-  optional: false
-- name: nest-asyncio
-  version: 1.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6598c056f64dc8800d40add25e4e2c34
-    sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
-  category: main
-  optional: false
-- name: nest-asyncio
-  version: 1.6.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/nest-asyncio-1.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6598c056f64dc8800d40add25e4e2c34
-    sha256: 30db21d1f7e59b3408b831a7e0417b83b53ee6223afae56482c5f26da3ceb49a
   category: main
   optional: false
 - name: networkx
@@ -13076,126 +11316,6 @@ package:
     sha256: d66c24024b652b6509a3ba5bc25d8b9cb6f6d46cd79ebacf7def1d758831d4b1
   category: main
   optional: false
-- name: overrides
-  version: 7.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    typing_utils: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
-    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
-  category: main
-  optional: false
-- name: overrides
-  version: 7.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    typing_utils: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
-    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
-  category: main
-  optional: false
-- name: overrides
-  version: 7.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    typing_utils: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
-    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
-  category: main
-  optional: false
-- name: overrides
-  version: 7.7.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    typing_utils: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/overrides-7.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 24fba5a9d161ad8103d4e84c0e1a3ed4
-    sha256: 5e238e5e646414d517a13f6786c7227206ace58271e3ef63f6adca4d6a4c2839
-  category: main
-  optional: false
-- name: owslib
-  version: 0.29.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    lxml: ''
-    python: '>=3.8'
-    python-dateutil: '>=1.5'
-    pytz: ''
-    pyyaml: ''
-    requests: '>=1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/owslib-0.29.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0a27c6854ced0189a5fa350c4064eac9
-    sha256: a0c60ebb81a46886f26b4b27dd7b2a9d0c752261a99d4623257ab3decdeeff51
-  category: main
-  optional: false
-- name: owslib
-  version: 0.29.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    pyyaml: ''
-    lxml: ''
-    pytz: ''
-    python: '>=3.8'
-    python-dateutil: '>=1.5'
-    requests: '>=1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/owslib-0.29.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0a27c6854ced0189a5fa350c4064eac9
-    sha256: a0c60ebb81a46886f26b4b27dd7b2a9d0c752261a99d4623257ab3decdeeff51
-  category: main
-  optional: false
-- name: owslib
-  version: 0.29.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    pyyaml: ''
-    lxml: ''
-    pytz: ''
-    python: '>=3.8'
-    python-dateutil: '>=1.5'
-    requests: '>=1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/owslib-0.29.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0a27c6854ced0189a5fa350c4064eac9
-    sha256: a0c60ebb81a46886f26b4b27dd7b2a9d0c752261a99d4623257ab3decdeeff51
-  category: main
-  optional: false
-- name: owslib
-  version: 0.29.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    pyyaml: ''
-    lxml: ''
-    pytz: ''
-    python: '>=3.8'
-    python-dateutil: '>=1.5'
-    requests: '>=1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/owslib-0.29.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0a27c6854ced0189a5fa350c4064eac9
-    sha256: a0c60ebb81a46886f26b4b27dd7b2a9d0c752261a99d4623257ab3decdeeff51
-  category: main
-  optional: false
 - name: packaging
   version: '23.2'
   manager: conda
@@ -13515,61 +11635,57 @@ package:
     sha256: 25e33b148478de58842ccc018fbabb414665de59270476e92c951203d4485bb1
   category: main
   optional: false
-- name: pdbufr
-  version: 0.11.0
+- name: pdfminer.six
+  version: '20231228'
   manager: conda
   platform: linux-64
   dependencies:
-    attrs: ''
-    pandas: ''
-    python: '>=3.7'
-    python-eccodes: '>=0.9.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pdbufr-0.11.0-pyhd8ed1ab_0.conda
+    charset-normalizer: '>=2.0.0'
+    cryptography: '>=36.0.0'
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pdfminer.six-20231228-pyhd8ed1ab_0.conda
   hash:
-    md5: 422748adcaf5c23c8c0f7ea84e7469c4
-    sha256: 9009014de36efeb31d5d42a0fbf4704c59f9c7714a957b7aad66997a753aa90e
+    md5: e61f6b78673ea5e0273592cfc76eb16d
+    sha256: 3d57473e40c6fefca597eb394f1b25a6e2353e2597bae13137a70179ad4a3044
   category: main
   optional: false
-- name: pdbufr
-  version: 0.11.0
+- name: pdfminer.six
+  version: '20231228'
   manager: conda
   platform: osx-64
   dependencies:
-    pandas: ''
-    attrs: ''
-    python: '>=3.7'
-    python-eccodes: '>=0.9.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pdbufr-0.11.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    cryptography: '>=36.0.0'
+    charset-normalizer: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pdfminer.six-20231228-pyhd8ed1ab_0.conda
   hash:
-    md5: 422748adcaf5c23c8c0f7ea84e7469c4
-    sha256: 9009014de36efeb31d5d42a0fbf4704c59f9c7714a957b7aad66997a753aa90e
+    md5: e61f6b78673ea5e0273592cfc76eb16d
+    sha256: 3d57473e40c6fefca597eb394f1b25a6e2353e2597bae13137a70179ad4a3044
   category: main
   optional: false
-- name: pdbufr
-  version: 0.11.0
+- name: pdfminer.six
+  version: '20231228'
   manager: conda
   platform: osx-arm64
   dependencies:
-    pandas: ''
-    attrs: ''
-    python: '>=3.7'
-    python-eccodes: '>=0.9.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pdbufr-0.11.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    cryptography: '>=36.0.0'
+    charset-normalizer: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pdfminer.six-20231228-pyhd8ed1ab_0.conda
   hash:
-    md5: 422748adcaf5c23c8c0f7ea84e7469c4
-    sha256: 9009014de36efeb31d5d42a0fbf4704c59f9c7714a957b7aad66997a753aa90e
+    md5: e61f6b78673ea5e0273592cfc76eb16d
+    sha256: 3d57473e40c6fefca597eb394f1b25a6e2353e2597bae13137a70179ad4a3044
   category: main
   optional: false
-- name: pdbufr
-  version: 0.11.0
+- name: pdfminer.six
+  version: '20231228'
   manager: conda
   platform: win-64
   dependencies:
-    pandas: ''
-    attrs: ''
-    python: '>=3.7'
-    python-eccodes: '>=0.9.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pdbufr-0.11.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+    cryptography: '>=36.0.0'
+    charset-normalizer: '>=2.0.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/pdfminer.six-20231228-pyhd8ed1ab_0.conda
   hash:
     md5: 422748adcaf5c23c8c0f7ea84e7469c4
     sha256: 9009014de36efeb31d5d42a0fbf4704c59f9c7714a957b7aad66997a753aa90e
@@ -13915,102 +12031,6 @@ package:
   hash:
     md5: 1060b0e26af2192e80b1d04cae0b029f
     sha256: 659db230ba8121395b23fa6fce5f16532f54e4e7397ff9e7c19d9c7e436d29f8
-  category: main
-  optional: false
-- name: pkgutil-resolve-name
-  version: 1.3.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-  hash:
-    md5: 405678b942f2481cecdb3e010f4925d9
-    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
-  category: main
-  optional: false
-- name: pkgutil-resolve-name
-  version: 1.3.10
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-  hash:
-    md5: 405678b942f2481cecdb3e010f4925d9
-    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
-  category: main
-  optional: false
-- name: pkgutil-resolve-name
-  version: 1.3.10
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-  hash:
-    md5: 405678b942f2481cecdb3e010f4925d9
-    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
-  category: main
-  optional: false
-- name: pkgutil-resolve-name
-  version: 1.3.10
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pkgutil-resolve-name-1.3.10-pyhd8ed1ab_1.conda
-  hash:
-    md5: 405678b942f2481cecdb3e010f4925d9
-    sha256: fecf95377134b0e8944762d92ecf7b0149c07d8186fb5db583125a2705c7ea0a
-  category: main
-  optional: false
-- name: platformdirs
-  version: 4.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0bc3eec34b0fab84be6b2da94e98e20
-    sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
-  category: main
-  optional: false
-- name: platformdirs
-  version: 4.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0bc3eec34b0fab84be6b2da94e98e20
-    sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
-  category: main
-  optional: false
-- name: platformdirs
-  version: 4.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0bc3eec34b0fab84be6b2da94e98e20
-    sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
-  category: main
-  optional: false
-- name: platformdirs
-  version: 4.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.2.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0bc3eec34b0fab84be6b2da94e98e20
-    sha256: 2ebfb971236ab825dd79dd6086ea742a9901008ffb9c6222c1f2b5172a8039d3
   category: main
   optional: false
 - name: pluggy
@@ -14364,210 +12384,6 @@ package:
     sha256: bcf34f3610e2c34a74fccf76e47e0fd41d36afd8fc043920fef0ab34230bcd01
   category: main
   optional: false
-- name: prometheus_client
-  version: 0.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.19.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7baa10fa8073c371155cf451b71b848d
-    sha256: 1235a3dbb033f914163e0deaf22d244cb1c1b5d8829d0089e38c34079286acbe
-  category: main
-  optional: false
-- name: prometheus_client
-  version: 0.19.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.19.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7baa10fa8073c371155cf451b71b848d
-    sha256: 1235a3dbb033f914163e0deaf22d244cb1c1b5d8829d0089e38c34079286acbe
-  category: main
-  optional: false
-- name: prometheus_client
-  version: 0.19.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.19.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7baa10fa8073c371155cf451b71b848d
-    sha256: 1235a3dbb033f914163e0deaf22d244cb1c1b5d8829d0089e38c34079286acbe
-  category: main
-  optional: false
-- name: prometheus_client
-  version: 0.19.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.19.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7baa10fa8073c371155cf451b71b848d
-    sha256: 1235a3dbb033f914163e0deaf22d244cb1c1b5d8829d0089e38c34079286acbe
-  category: main
-  optional: false
-- name: prompt-toolkit
-  version: 3.0.42
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-    wcwidth: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
-  hash:
-    md5: 0bf64bf10eee21f46ac83c161917fa86
-    sha256: 58525b2a9305fb154b2b0d43a48b9a6495441b80e4fbea44f2a34a597d2cef16
-  category: main
-  optional: false
-- name: prompt-toolkit
-  version: 3.0.42
-  manager: conda
-  platform: osx-64
-  dependencies:
-    wcwidth: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
-  hash:
-    md5: 0bf64bf10eee21f46ac83c161917fa86
-    sha256: 58525b2a9305fb154b2b0d43a48b9a6495441b80e4fbea44f2a34a597d2cef16
-  category: main
-  optional: false
-- name: prompt-toolkit
-  version: 3.0.42
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    wcwidth: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
-  hash:
-    md5: 0bf64bf10eee21f46ac83c161917fa86
-    sha256: 58525b2a9305fb154b2b0d43a48b9a6495441b80e4fbea44f2a34a597d2cef16
-  category: main
-  optional: false
-- name: prompt-toolkit
-  version: 3.0.42
-  manager: conda
-  platform: win-64
-  dependencies:
-    wcwidth: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.42-pyha770c72_0.conda
-  hash:
-    md5: 0bf64bf10eee21f46ac83c161917fa86
-    sha256: 58525b2a9305fb154b2b0d43a48b9a6495441b80e4fbea44f2a34a597d2cef16
-  category: main
-  optional: false
-- name: prompt_toolkit
-  version: 3.0.42
-  manager: conda
-  platform: linux-64
-  dependencies:
-    prompt-toolkit: '>=3.0.42,<3.0.43.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.42-hd8ed1ab_0.conda
-  hash:
-    md5: 85a2189ecd2fcdd86e92b2d4ea8fe461
-    sha256: fd2185d501bf34cb4c121f2f5ade9157ac75e1644a9da81355c4c8f9c1b82d4d
-  category: main
-  optional: false
-- name: prompt_toolkit
-  version: 3.0.42
-  manager: conda
-  platform: osx-64
-  dependencies:
-    prompt-toolkit: '>=3.0.42,<3.0.43.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.42-hd8ed1ab_0.conda
-  hash:
-    md5: 85a2189ecd2fcdd86e92b2d4ea8fe461
-    sha256: fd2185d501bf34cb4c121f2f5ade9157ac75e1644a9da81355c4c8f9c1b82d4d
-  category: main
-  optional: false
-- name: prompt_toolkit
-  version: 3.0.42
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    prompt-toolkit: '>=3.0.42,<3.0.43.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.42-hd8ed1ab_0.conda
-  hash:
-    md5: 85a2189ecd2fcdd86e92b2d4ea8fe461
-    sha256: fd2185d501bf34cb4c121f2f5ade9157ac75e1644a9da81355c4c8f9c1b82d4d
-  category: main
-  optional: false
-- name: prompt_toolkit
-  version: 3.0.42
-  manager: conda
-  platform: win-64
-  dependencies:
-    prompt-toolkit: '>=3.0.42,<3.0.43.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.42-hd8ed1ab_0.conda
-  hash:
-    md5: 85a2189ecd2fcdd86e92b2d4ea8fe461
-    sha256: fd2185d501bf34cb4c121f2f5ade9157ac75e1644a9da81355c4c8f9c1b82d4d
-  category: main
-  optional: false
-- name: psutil
-  version: 5.9.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/psutil-5.9.8-py312h98912ed_0.conda
-  hash:
-    md5: 3facaca6cc0f7988df3250efccd32da3
-    sha256: 27e7f8f5d30c74439f39d61e21ac14c0cd03b5d55f7bf9f946fb619016f73c61
-  category: main
-  optional: false
-- name: psutil
-  version: 5.9.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/psutil-5.9.8-py312h41838bb_0.conda
-  hash:
-    md5: 03926e7089a5e61b77043b470ae7b553
-    sha256: 12e5053d19bddaf7841e59cbe9ba98fa5d4d8502ceccddad80888515e1366107
-  category: main
-  optional: false
-- name: psutil
-  version: 5.9.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-5.9.8-py312he37b823_0.conda
-  hash:
-    md5: cd6e99b9c5a623735161973b5f693a86
-    sha256: a996bd5f878da264d1d3ba7fde717b0a2c158a86645efb1e899d087cca74832d
-  category: main
-  optional: false
-- name: psutil
-  version: 5.9.8
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/psutil-5.9.8-py312he70551f_0.conda
-  hash:
-    md5: 5f2998851564bea33a159bd00e6249e8
-    sha256: 36f8addb327f80da4d6bd421170ff4cf8fb570d9ee8df39372427a4e33298dca
-  category: main
-  optional: false
 - name: pthread-stubs
   version: '0.4'
   manager: conda
@@ -14624,90 +12440,6 @@ package:
   hash:
     md5: e2da8758d7d51ff6aa78a14dfb9dbed4
     sha256: 576a228630a72f25d255a5e345e5f10878e153221a96560f2498040cd6f54005
-  category: main
-  optional: false
-- name: ptyprocess
-  version: 0.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-  category: main
-  optional: false
-- name: ptyprocess
-  version: 0.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-  category: main
-  optional: false
-- name: ptyprocess
-  version: 0.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd3deb0d_0.tar.bz2
-  hash:
-    md5: 359eeb6536da0e687af562ed265ec263
-    sha256: fb31e006a25eb2e18f3440eb8d17be44c8ccfae559499199f73584566d0a444a
-  category: main
-  optional: false
-- name: pure_eval
-  version: 0.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
-  category: main
-  optional: false
-- name: pure_eval
-  version: 0.2.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
-  category: main
-  optional: false
-- name: pure_eval
-  version: 0.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
-  category: main
-  optional: false
-- name: pure_eval
-  version: 0.2.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 6784285c7e55cb7212efabc79e4c2883
-    sha256: 72792f9fc2b1820e37cc57f84a27bc819c71088c3002ca6db05a2e56404f9d44
   category: main
   optional: false
 - name: pyarrow
@@ -14851,114 +12583,6 @@ package:
   hash:
     md5: 076becd9e05608f8dc72757d5f3a91ff
     sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
-  category: main
-  optional: false
-- name: pygments
-  version: 2.17.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 140a7f159396547e9799aa98f9f0742e
-    sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
-  category: main
-  optional: false
-- name: pygments
-  version: 2.17.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 140a7f159396547e9799aa98f9f0742e
-    sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
-  category: main
-  optional: false
-- name: pygments
-  version: 2.17.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 140a7f159396547e9799aa98f9f0742e
-    sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
-  category: main
-  optional: false
-- name: pygments
-  version: 2.17.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pygments-2.17.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 140a7f159396547e9799aa98f9f0742e
-    sha256: af5f8867450dc292f98ea387d4d8945fc574284677c8f60eaa9846ede7387257
-  category: main
-  optional: false
-- name: pyobjc-core
-  version: '10.1'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libffi: '>=3.4,<4.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-core-10.1-py312h74abf1d_0.conda
-  hash:
-    md5: 87740b1b13db8da52bedfe90145e1a84
-    sha256: 3863e71aa5d895893a85122945875d3e4e95ca4e973d8e06f3f60cbb0de6b42e
-  category: main
-  optional: false
-- name: pyobjc-core
-  version: '10.1'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libffi: '>=3.4,<4.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    setuptools: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-core-10.1-py312h9d22092_0.conda
-  hash:
-    md5: dfdb0f8a37baf06a8dec8dd270c23753
-    sha256: 06a95d717dfb01a7179e2008d77ada2c58c5c900dc1d36f95068ccd170f49a89
-  category: main
-  optional: false
-- name: pyobjc-framework-cocoa
-  version: '10.1'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libffi: '>=3.4,<4.0a0'
-    pyobjc-core: 10.1.*
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyobjc-framework-cocoa-10.1-py312h74abf1d_0.conda
-  hash:
-    md5: c3b820baa2320e8493011c69bfb987f7
-    sha256: 6ebc8e7154298a8b3f93bcabc6020d8159d1544cf711342a0769f633a4af7cfa
-  category: main
-  optional: false
-- name: pyobjc-framework-cocoa
-  version: '10.1'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libffi: '>=3.4,<4.0a0'
-    pyobjc-core: 10.1.*
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyobjc-framework-cocoa-10.1-py312h9d22092_0.conda
-  hash:
-    md5: 27dc04bb8bb427ee52facd69f7a6cabb
-    sha256: a6a4e8b5bd67d054c0c731cf86795d8040a9cc1c6a92d5116115e4cf4e59beec
   category: main
   optional: false
 - name: pyparsing
@@ -15348,173 +12972,101 @@ package:
     sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
   category: main
   optional: false
-- name: python-eccodes
-  version: 1.6.1
+- name: python-slugify
+  version: 8.0.4
   manager: conda
   platform: linux-64
   dependencies:
-    attrs: ''
-    cffi: ''
-    eccodes: '>=2.31.0'
-    findlibs: ''
-    libgcc-ng: '>=12'
-    numpy: '>=1.26.0,<2.0a0'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-eccodes-1.6.1-py312hc7c0aa3_1.conda
+    python: '>=3.7'
+    text-unidecode: '>=1.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 6103168b0bbc93d81ab290114f638611
-    sha256: ef4ace7a1a97c64e471c171ac3630e37e7c01a2bc08faca19f86f2f89bb11869
+    md5: 4b11845622b3c3178c0e989235b53975
+    sha256: a1270bfd4f1d648766c8f95403f208e50d34af94761bc553a960102c6bff9fa0
   category: main
   optional: false
-- name: python-eccodes
-  version: 1.6.1
+- name: python-slugify
+  version: 8.0.4
   manager: conda
   platform: osx-64
   dependencies:
-    attrs: ''
-    cffi: ''
-    eccodes: '>=2.31.0'
-    findlibs: ''
-    numpy: '>=1.26.0,<2.0a0'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-eccodes-1.6.1-py312h5d6a8aa_1.conda
+    python: '>=3.7'
+    text-unidecode: '>=1.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 3271aa6cc5d63aacecf5d92c6fac3034
-    sha256: db63108570dd0c041afe87ba421495f88d9c1d06434ec97f15080f2a8d3d96c6
+    md5: 4b11845622b3c3178c0e989235b53975
+    sha256: a1270bfd4f1d648766c8f95403f208e50d34af94761bc553a960102c6bff9fa0
   category: main
   optional: false
-- name: python-eccodes
-  version: 1.6.1
+- name: python-slugify
+  version: 8.0.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    attrs: ''
-    cffi: ''
-    eccodes: '>=2.31.0'
-    findlibs: ''
-    numpy: '>=1.26.0,<2.0a0'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-eccodes-1.6.1-py312h3339331_1.conda
+    python: '>=3.7'
+    text-unidecode: '>=1.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
   hash:
-    md5: f8c8a14089edd34428b9c18a2d0afcef
-    sha256: 978e8c62cef7b10654a7e23bd63f1ca8866c99ff3e6412af49c38d4ac3955038
+    md5: 4b11845622b3c3178c0e989235b53975
+    sha256: a1270bfd4f1d648766c8f95403f208e50d34af94761bc553a960102c6bff9fa0
   category: main
   optional: false
-- name: python-eccodes
-  version: 1.6.1
+- name: python-slugify
+  version: 8.0.4
   manager: conda
   platform: win-64
   dependencies:
-    attrs: ''
-    cffi: ''
-    eccodes: '>=2.31.0'
-    findlibs: ''
-    numpy: '>=1.26.0,<2.0a0'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/python-eccodes-1.6.1-py312ha90f08f_1.conda
+    python: '>=3.7'
+    text-unidecode: '>=1.3'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
   hash:
-    md5: 2fb31cd83dd09b2fd439a44567594d80
-    sha256: a92e1465cafdd20c9b0a66076be509bebd3a0cc8ee0d9a2b2626fe2b16c8df8a
+    md5: 4b11845622b3c3178c0e989235b53975
+    sha256: a1270bfd4f1d648766c8f95403f208e50d34af94761bc553a960102c6bff9fa0
   category: main
   optional: false
-- name: python-fastjsonschema
-  version: 2.19.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4d3ceee3af4b0f9a1f48f57176bf8625
-    sha256: 38b2db169d65cc5595e3ce63294c4fdb6a242ecf71f70b3ad8cad3bd4230d82f
-  category: main
-  optional: false
-- name: python-fastjsonschema
-  version: 2.19.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4d3ceee3af4b0f9a1f48f57176bf8625
-    sha256: 38b2db169d65cc5595e3ce63294c4fdb6a242ecf71f70b3ad8cad3bd4230d82f
-  category: main
-  optional: false
-- name: python-fastjsonschema
-  version: 2.19.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4d3ceee3af4b0f9a1f48f57176bf8625
-    sha256: 38b2db169d65cc5595e3ce63294c4fdb6a242ecf71f70b3ad8cad3bd4230d82f
-  category: main
-  optional: false
-- name: python-fastjsonschema
-  version: 2.19.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-fastjsonschema-2.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 4d3ceee3af4b0f9a1f48f57176bf8625
-    sha256: 38b2db169d65cc5595e3ce63294c4fdb6a242ecf71f70b3ad8cad3bd4230d82f
-  category: main
-  optional: false
-- name: python-json-logger
-  version: 2.0.7
+- name: python-tzdata
+  version: '2024.1'
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a61bf9ec79426938ff785eb69dbb1960
-    sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+    md5: 98206ea9954216ee7540f0c773f2104d
+    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
   category: main
   optional: false
-- name: python-json-logger
-  version: 2.0.7
+- name: python-tzdata
+  version: '2024.1'
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a61bf9ec79426938ff785eb69dbb1960
-    sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+    md5: 98206ea9954216ee7540f0c773f2104d
+    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
   category: main
   optional: false
-- name: python-json-logger
-  version: 2.0.7
+- name: python-tzdata
+  version: '2024.1'
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
   hash:
-    md5: a61bf9ec79426938ff785eb69dbb1960
-    sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+    md5: 98206ea9954216ee7540f0c773f2104d
+    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
   category: main
   optional: false
-- name: python-json-logger
-  version: 2.0.7
+- name: python-tzdata
+  version: '2024.1'
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-json-logger-2.0.7-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
   hash:
     md5: a61bf9ec79426938ff785eb69dbb1960
     sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
@@ -15712,296 +13264,6 @@ package:
     sha256: 1a7d6b233f7e6e3bbcbad054c8fd51e690a67b129a899a056a5e45dd9f00cb41
   category: main
   optional: false
-- name: pywin32
-  version: '306'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pywin32-306-py312h53d5487_2.conda
-  hash:
-    md5: f44c8f35c3f99eca30d6f5b68ddb0f42
-    sha256: d0ff1cd887b626a125f8323760736d8fab496bf2a400e825cce55361e7631264
-  category: main
-  optional: false
-- name: pywinpty
-  version: 2.0.12
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    winpty: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/pywinpty-2.0.12-py312h53d5487_0.conda
-  hash:
-    md5: 9d6df56b1b0e5ba19160932e6bac356f
-    sha256: d7ed8a8a798a4c43581cefa370d91b90aff2a279d0256c4b04331a4e357c3625
-  category: main
-  optional: false
-- name: pyyaml
-  version: 6.0.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.1-py312h98912ed_1.conda
-  hash:
-    md5: e3fd78d8d490af1d84763b9fe3f2e552
-    sha256: 7f347a10a7121b08d79d21cd4f438c07c23479ea0c74dfb89d6dc416f791bb7f
-  category: main
-  optional: false
-- name: pyyaml
-  version: 6.0.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyyaml-6.0.1-py312h104f124_1.conda
-  hash:
-    md5: 260ed90aaf06061edabd7209638cf03b
-    sha256: 04aa180782cb675b960c0bf4aad439b4a7a08553c6af74d0b8e5df9a0c7cc4f4
-  category: main
-  optional: false
-- name: pyyaml
-  version: 6.0.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.1-py312h02f2b3b_1.conda
-  hash:
-    md5: a0c843e52a1c4422d8657dd76e9eb994
-    sha256: b6b4027b89c17b9bbd8089aec3e44bc29f802a7d5668d5a75b5358d7ed9705ca
-  category: main
-  optional: false
-- name: pyyaml
-  version: 6.0.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    yaml: '>=0.2.5,<0.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyyaml-6.0.1-py312he70551f_1.conda
-  hash:
-    md5: f91e0baa89ba21166916624ba7bfb422
-    sha256: a72fa8152791b4738432f270e70b3a9a4d583ef059a78aa1c62f4b4ab7b15494
-  category: main
-  optional: false
-- name: pyzmq
-  version: 25.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    libstdcxx-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyzmq-25.1.2-py312h886d080_0.conda
-  hash:
-    md5: cc2cdf8f1792d29d21e17024745813d8
-    sha256: 5aa0ba1f67e2b25ede34a713df6655e519211a96ea109857768930d96bcd0ca0
-  category: main
-  optional: false
-- name: pyzmq
-  version: 25.1.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyzmq-25.1.2-py312hc789acb_0.conda
-  hash:
-    md5: af49da330d412bc3203bc84f8153d685
-    sha256: 1e5fb7095be7edb90efd50cde7b417bf4f1f5ae216d0b597ada61ee201f56d29
-  category: main
-  optional: false
-- name: pyzmq
-  version: 25.1.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    zeromq: '>=4.3.5,<4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyzmq-25.1.2-py312h1edf716_0.conda
-  hash:
-    md5: 913db29987f836f5d80fa319e36b0a33
-    sha256: a89712c6b0cab1e3385e44e0130a57b9d03df99b6f540486c0f00e2dae079e77
-  category: main
-  optional: false
-- name: pyzmq
-  version: 25.1.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-    zeromq: '>=4.3.5,<4.3.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyzmq-25.1.2-py312h1ac6f91_0.conda
-  hash:
-    md5: 74194f888cc7b11d8c18edf416b61a1b
-    sha256: 9371101999c75aa562c5aa4ae0dfefa140bee635a3f8e15768628689f70d7765
-  category: main
-  optional: false
-- name: qtconsole-base
-  version: 5.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ipykernel: '>=4.1'
-    jupyter_client: '>=4.1'
-    jupyter_core: ''
-    packaging: ''
-    pygments: ''
-    python: '>=3.8'
-    qtpy: '>=2.4.0'
-    traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/qtconsole-base-5.5.1-pyha770c72_0.conda
-  hash:
-    md5: 5528a3eda283b421055c89bface19a1c
-    sha256: e81a294941a598aabfd9462cf9aaa3b3e2c04996420f82494bdc13233de8ca70
-  category: main
-  optional: false
-- name: qtconsole-base
-  version: 5.5.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    packaging: ''
-    pygments: ''
-    traitlets: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    ipykernel: '>=4.1'
-    jupyter_client: '>=4.1'
-    qtpy: '>=2.4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qtconsole-base-5.5.1-pyha770c72_0.conda
-  hash:
-    md5: 5528a3eda283b421055c89bface19a1c
-    sha256: e81a294941a598aabfd9462cf9aaa3b3e2c04996420f82494bdc13233de8ca70
-  category: main
-  optional: false
-- name: qtconsole-base
-  version: 5.5.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    packaging: ''
-    pygments: ''
-    traitlets: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    ipykernel: '>=4.1'
-    jupyter_client: '>=4.1'
-    qtpy: '>=2.4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qtconsole-base-5.5.1-pyha770c72_0.conda
-  hash:
-    md5: 5528a3eda283b421055c89bface19a1c
-    sha256: e81a294941a598aabfd9462cf9aaa3b3e2c04996420f82494bdc13233de8ca70
-  category: main
-  optional: false
-- name: qtconsole-base
-  version: 5.5.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    packaging: ''
-    pygments: ''
-    traitlets: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    ipykernel: '>=4.1'
-    jupyter_client: '>=4.1'
-    qtpy: '>=2.4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/qtconsole-base-5.5.1-pyha770c72_0.conda
-  hash:
-    md5: 5528a3eda283b421055c89bface19a1c
-    sha256: e81a294941a598aabfd9462cf9aaa3b3e2c04996420f82494bdc13233de8ca70
-  category: main
-  optional: false
-- name: qtpy
-  version: 2.4.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    packaging: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f391bd70d2abfb70f304ba5aa4e1261
-    sha256: 925bf48e747af6ceff1b073c10b12fc94ef79c88a34729059d253e43466a33f1
-  category: main
-  optional: false
-- name: qtpy
-  version: 2.4.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    packaging: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f391bd70d2abfb70f304ba5aa4e1261
-    sha256: 925bf48e747af6ceff1b073c10b12fc94ef79c88a34729059d253e43466a33f1
-  category: main
-  optional: false
-- name: qtpy
-  version: 2.4.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    packaging: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f391bd70d2abfb70f304ba5aa4e1261
-    sha256: 925bf48e747af6ceff1b073c10b12fc94ef79c88a34729059d253e43466a33f1
-  category: main
-  optional: false
-- name: qtpy
-  version: 2.4.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    packaging: ''
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/qtpy-2.4.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7f391bd70d2abfb70f304ba5aa4e1261
-    sha256: 925bf48e747af6ceff1b073c10b12fc94ef79c88a34729059d253e43466a33f1
-  category: main
-  optional: false
 - name: rdma-core
   version: '50.0'
   manager: conda
@@ -16102,62 +13364,6 @@ package:
     sha256: a1dfa679ac3f6007362386576a704ad2d0d7a02e98f5d0b115f207a2da63e884
   category: main
   optional: false
-- name: referencing
-  version: 0.33.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    attrs: '>=22.2.0'
-    python: '>=3.8'
-    rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: bc415a1c6cf049166215d6b596e0fcbe
-    sha256: 5707eb9ee2c7cfcc56a5223b24ab3133ff61aaa796931f3b22068e0a43ea6ecf
-  category: main
-  optional: false
-- name: referencing
-  version: 0.33.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    attrs: '>=22.2.0'
-    rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: bc415a1c6cf049166215d6b596e0fcbe
-    sha256: 5707eb9ee2c7cfcc56a5223b24ab3133ff61aaa796931f3b22068e0a43ea6ecf
-  category: main
-  optional: false
-- name: referencing
-  version: 0.33.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    attrs: '>=22.2.0'
-    rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: bc415a1c6cf049166215d6b596e0fcbe
-    sha256: 5707eb9ee2c7cfcc56a5223b24ab3133ff61aaa796931f3b22068e0a43ea6ecf
-  category: main
-  optional: false
-- name: referencing
-  version: 0.33.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    attrs: '>=22.2.0'
-    rpds-py: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/referencing-0.33.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: bc415a1c6cf049166215d6b596e0fcbe
-    sha256: 5707eb9ee2c7cfcc56a5223b24ab3133ff61aaa796931f3b22068e0a43ea6ecf
-  category: main
-  optional: false
 - name: requests
   version: 2.31.0
   manager: conda
@@ -16220,162 +13426,6 @@ package:
   hash:
     md5: a30144e4156cdbb236f99ebb49828f8b
     sha256: 9f629d6fd3c8ac5f2a198639fe7af87c4db2ac9235279164bfe0fcb49d8c4bad
-  category: main
-  optional: false
-- name: rfc3339-validator
-  version: 0.1.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: fed45fc5ea0813240707998abe49f520
-    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
-  category: main
-  optional: false
-- name: rfc3339-validator
-  version: 0.1.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    six: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: fed45fc5ea0813240707998abe49f520
-    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
-  category: main
-  optional: false
-- name: rfc3339-validator
-  version: 0.1.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    six: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: fed45fc5ea0813240707998abe49f520
-    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
-  category: main
-  optional: false
-- name: rfc3339-validator
-  version: 0.1.4
-  manager: conda
-  platform: win-64
-  dependencies:
-    six: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3339-validator-0.1.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: fed45fc5ea0813240707998abe49f520
-    sha256: 7c7052b51de0b5c558f890bb11f8b5edbb9934a653d76be086b1182b9f54185d
-  category: main
-  optional: false
-- name: rfc3986-validator
-  version: 0.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 912a71cc01012ee38e6b90ddd561e36f
-    sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
-  category: main
-  optional: false
-- name: rfc3986-validator
-  version: 0.1.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 912a71cc01012ee38e6b90ddd561e36f
-    sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
-  category: main
-  optional: false
-- name: rfc3986-validator
-  version: 0.1.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 912a71cc01012ee38e6b90ddd561e36f
-    sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
-  category: main
-  optional: false
-- name: rfc3986-validator
-  version: 0.1.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/rfc3986-validator-0.1.1-pyh9f0ad1d_0.tar.bz2
-  hash:
-    md5: 912a71cc01012ee38e6b90ddd561e36f
-    sha256: 2a5b495a1de0f60f24d8a74578ebc23b24aa53279b1ad583755f223097c41c37
-  category: main
-  optional: false
-- name: rpds-py
-  version: 0.17.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.17.1-py312h4b3b743_0.conda
-  hash:
-    md5: c37fd4a53c4beb2838154df9abd185cd
-    sha256: 7fbe75361cd3780b4c61ae044ddf5fd5bffb2223c5688e1b1165671504e92eea
-  category: main
-  optional: false
-- name: rpds-py
-  version: 0.17.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/rpds-py-0.17.1-py312h6e28e45_0.conda
-  hash:
-    md5: d2282485c03ef768767dd65810b178d4
-    sha256: 2f60433da50c3b2b09a49af587dcec8d9d3b42623621bfaf38a789ae4cab6ff2
-  category: main
-  optional: false
-- name: rpds-py
-  version: 0.17.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/rpds-py-0.17.1-py312h5280bc4_0.conda
-  hash:
-    md5: 7b0b4879880d11be49c5edfdae68bc39
-    sha256: 1e6a413e4ed984cf9d62c4eb1b921ceb6efc3f8470dbfa2f5a23790724b8ff0d
-  category: main
-  optional: false
-- name: rpds-py
-  version: 0.17.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/rpds-py-0.17.1-py312hfccd98a_0.conda
-  hash:
-    md5: 3506d4bcb36b42850937fabdcc44bc90
-    sha256: a1b1649da36ffbe434d1c7a301dd31e18e8e816fb164f20657539a4ab882a914
   category: main
   optional: false
 - name: rtree
@@ -16606,61 +13656,6 @@ package:
     sha256: 71bc446397e64ca2f221b82fa485a3940559e041360c9c042260f47ae6a5989e
   category: main
   optional: false
-- name: send2trash
-  version: 1.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __linux: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh41d4057_0.conda
-  hash:
-    md5: ada5a17adcd10be4fc7e37e4166ba0e2
-    sha256: e74d3faf51a6cc429898da0209d95b209270160f3edbf2f6d8b61a99428301cd
-  category: main
-  optional: false
-- name: send2trash
-  version: 1.8.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: ''
-    pyobjc-framework-cocoa: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
-  hash:
-    md5: 2657c3de5371c571aef6678afb4aaadd
-    sha256: dca4022bae47618ed738ab7d45ead5202d174b741cfb98e4484acdc6e76da32a
-  category: main
-  optional: false
-- name: send2trash
-  version: 1.8.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: ''
-    pyobjc-framework-cocoa: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyhd1c38e8_0.conda
-  hash:
-    md5: 2657c3de5371c571aef6678afb4aaadd
-    sha256: dca4022bae47618ed738ab7d45ead5202d174b741cfb98e4484acdc6e76da32a
-  category: main
-  optional: false
-- name: send2trash
-  version: 1.8.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    __win: ''
-    pywin32: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/send2trash-1.8.2-pyh08f2357_0.conda
-  hash:
-    md5: c00d32dfa733d381b6a1908d0d67e0d7
-    sha256: 55208c6b48d68dc9ad2e2cf81ab9dc6b8a1d607e67acf9115bdc7794accc84bc
-  category: main
-  optional: false
 - name: setuptools
   version: 69.0.3
   manager: conda
@@ -16870,54 +13865,6 @@ package:
   hash:
     md5: cff1df79c9cff719460eb2dd172568de
     sha256: 2a195b38cb63f03ad9f73a82db52434ebefe216fb70f7ea3defe4ddf263d408a
-  category: main
-  optional: false
-- name: sniffio
-  version: 1.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd6cbc539e74cb1f430efbd4575b9303
-    sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
-  category: main
-  optional: false
-- name: sniffio
-  version: 1.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd6cbc539e74cb1f430efbd4575b9303
-    sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
-  category: main
-  optional: false
-- name: sniffio
-  version: 1.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd6cbc539e74cb1f430efbd4575b9303
-    sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
-  category: main
-  optional: false
-- name: sniffio
-  version: 1.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/sniffio-1.3.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd6cbc539e74cb1f430efbd4575b9303
-    sha256: a3fd30754c20ddb28b777db38345ea00d958f46701f0decd6291a81c0f4eee78
   category: main
   optional: false
 - name: soupsieve
@@ -17152,64 +14099,52 @@ package:
     sha256: aa30c089fdd6f66c7808592362e29963586e094159964a5fb61fb8efa9e349bc
   category: main
   optional: false
-- name: terminado
-  version: 0.18.0
+- name: text-unidecode
+  version: '1.3'
   manager: conda
   platform: linux-64
   dependencies:
-    __linux: ''
-    ptyprocess: ''
-    python: '>=3.8'
-    tornado: '>=6.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.0-pyh0d859eb_0.conda
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
   hash:
-    md5: e463f348b8b0eb62c9f7c6fbc780286c
-    sha256: e90139ef15ea9d75a69cd6b6302c29ed5b01c03ddfa717b71acb32b60af74269
+    md5: ba8aba332d8868897ce44ad74015a7fe
+    sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
   category: main
   optional: false
-- name: terminado
-  version: 0.18.0
+- name: text-unidecode
+  version: '1.3'
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: ''
-    ptyprocess: ''
-    python: '>=3.8'
-    tornado: '>=6.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.0-pyh31c8845_0.conda
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 14759b57f5b9d97033e633fff0a2d27e
-    sha256: 8e8741c688ade9be8f86c0b209780c7fbe4a97e4265311ca9d8dda5fcedc6a28
+    md5: ba8aba332d8868897ce44ad74015a7fe
+    sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
   category: main
   optional: false
-- name: terminado
-  version: 0.18.0
+- name: text-unidecode
+  version: '1.3'
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: ''
-    ptyprocess: ''
-    python: '>=3.8'
-    tornado: '>=6.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.0-pyh31c8845_0.conda
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
   hash:
-    md5: 14759b57f5b9d97033e633fff0a2d27e
-    sha256: 8e8741c688ade9be8f86c0b209780c7fbe4a97e4265311ca9d8dda5fcedc6a28
+    md5: ba8aba332d8868897ce44ad74015a7fe
+    sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
   category: main
   optional: false
-- name: terminado
-  version: 0.18.0
+- name: text-unidecode
+  version: '1.3'
   manager: conda
   platform: win-64
   dependencies:
-    __win: ''
-    python: '>=3.8'
-    tornado: '>=6.1.0'
-    pywinpty: '>=1.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/terminado-0.18.0-pyh5737063_0.conda
+    python: '>=3.4'
+  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
   hash:
-    md5: f2fc93bc1e08e04612c4d19361bb0011
-    sha256: 4353d8d2372ad050cbdab05890c057356ea8693ecfb959396ebb8ffdfc1948bf
+    md5: ba8aba332d8868897ce44ad74015a7fe
+    sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
   category: main
   optional: false
 - name: text-unidecode
@@ -17261,51 +14196,51 @@ package:
   category: main
   optional: false
 - name: threadpoolctl
-  version: 3.2.0
+  version: 3.3.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.2.0-pyha21a80b_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
   hash:
-    md5: 978d03388b62173b8e6f79162cf52b86
-    sha256: 15e2f916fbfe3cc480160aa99eb6ba3edc183fceb234f10151d63870fdc4eccd
+    md5: 698d2d2b621640bddb9191f132967c9f
+    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
   category: main
   optional: false
 - name: threadpoolctl
-  version: 3.2.0
+  version: 3.3.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.2.0-pyha21a80b_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
   hash:
-    md5: 978d03388b62173b8e6f79162cf52b86
-    sha256: 15e2f916fbfe3cc480160aa99eb6ba3edc183fceb234f10151d63870fdc4eccd
+    md5: 698d2d2b621640bddb9191f132967c9f
+    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
   category: main
   optional: false
 - name: threadpoolctl
-  version: 3.2.0
+  version: 3.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.2.0-pyha21a80b_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
   hash:
-    md5: 978d03388b62173b8e6f79162cf52b86
-    sha256: 15e2f916fbfe3cc480160aa99eb6ba3edc183fceb234f10151d63870fdc4eccd
+    md5: 698d2d2b621640bddb9191f132967c9f
+    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
   category: main
   optional: false
 - name: threadpoolctl
-  version: 3.2.0
+  version: 3.3.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.2.0-pyha21a80b_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
   hash:
-    md5: 978d03388b62173b8e6f79162cf52b86
-    sha256: 15e2f916fbfe3cc480160aa99eb6ba3edc183fceb234f10151d63870fdc4eccd
+    md5: 698d2d2b621640bddb9191f132967c9f
+    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
   category: main
   optional: false
 - name: tiledb
@@ -17409,58 +14344,6 @@ package:
     sha256: 01ab52856318cbd7192bafdc9cf5461e143811ba0ed048ea531c0e313d6b4a2d
   category: main
   optional: false
-- name: tinycss2
-  version: 1.2.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-    webencodings: '>=0.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 7234c9eefff659501cd2fe0d2ede4d48
-    sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
-  category: main
-  optional: false
-- name: tinycss2
-  version: 1.2.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-    webencodings: '>=0.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 7234c9eefff659501cd2fe0d2ede4d48
-    sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
-  category: main
-  optional: false
-- name: tinycss2
-  version: 1.2.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-    webencodings: '>=0.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 7234c9eefff659501cd2fe0d2ede4d48
-    sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
-  category: main
-  optional: false
-- name: tinycss2
-  version: 1.2.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.5'
-    webencodings: '>=0.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/tinycss2-1.2.1-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 7234c9eefff659501cd2fe0d2ede4d48
-    sha256: f0db1a2298a5e10e30f4b947566c7229442834702f549dded40a73ecdea7502d
-  category: main
-  optional: false
 - name: tk
   version: 8.6.13
   manager: conda
@@ -17558,302 +14441,6 @@ package:
   hash:
     md5: 5844808ffab9ebdb694585b50ba02a96
     sha256: 4cd48aba7cd026d17e86886af48d0d2ebc67ed36f87f6534f4b67138f5a5a58f
-  category: main
-  optional: false
-- name: tornado
-  version: 6.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.3.3-py312h98912ed_1.conda
-  hash:
-    md5: 5bd63a3bf512694536cee3e48463a47c
-    sha256: 970d4e3e0b9b34dc8383055a956d4a9158a9f527264bc7ece769ba284d2395ff
-  category: main
-  optional: false
-- name: tornado
-  version: 6.3.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/tornado-6.3.3-py312h104f124_1.conda
-  hash:
-    md5: 6835d4940d6fbd41e1a32d58dfae8f06
-    sha256: 7f4f2a3a43c0bf62025b46f28366598aa04e0d4a32c87bfe4a275b4df562eba3
-  category: main
-  optional: false
-- name: tornado
-  version: 6.3.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tornado-6.3.3-py312h02f2b3b_1.conda
-  hash:
-    md5: 3ec18cacdeb6f7a87fee073b28bc7118
-    sha256: f59281be797e9cfa2f1cfd5bff89a8268823e98fe49aaa6bede9a91b27e887ab
-  category: main
-  optional: false
-- name: tornado
-  version: 6.3.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/tornado-6.3.3-py312he70551f_1.conda
-  hash:
-    md5: a3bebd12ad9b94a4b9c46f8fd197e883
-    sha256: 196ceac8b914e71706c2a45907c20ef10ae097e0c2775950ad232065659026d6
-  category: main
-  optional: false
-- name: traitlets
-  version: 5.14.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1c6acfdc7ecbfe09954c4216da99c146
-    sha256: fa78d68f74ec8aae5c93f135140bfdbbf0ab60a79c6062b55d73c316068545ec
-  category: main
-  optional: false
-- name: traitlets
-  version: 5.14.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1c6acfdc7ecbfe09954c4216da99c146
-    sha256: fa78d68f74ec8aae5c93f135140bfdbbf0ab60a79c6062b55d73c316068545ec
-  category: main
-  optional: false
-- name: traitlets
-  version: 5.14.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1c6acfdc7ecbfe09954c4216da99c146
-    sha256: fa78d68f74ec8aae5c93f135140bfdbbf0ab60a79c6062b55d73c316068545ec
-  category: main
-  optional: false
-- name: traitlets
-  version: 5.14.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/traitlets-5.14.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 1c6acfdc7ecbfe09954c4216da99c146
-    sha256: fa78d68f74ec8aae5c93f135140bfdbbf0ab60a79c6062b55d73c316068545ec
-  category: main
-  optional: false
-- name: types-python-dateutil
-  version: 2.8.19.20240106
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.20240106-pyhd8ed1ab_0.conda
-  hash:
-    md5: c9096a546660b9079dce531c0039e074
-    sha256: 09ef8cc587bdea80a83b6f820dbae24daadcf82be088fb0a9f6495781653e300
-  category: main
-  optional: false
-- name: types-python-dateutil
-  version: 2.8.19.20240106
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.20240106-pyhd8ed1ab_0.conda
-  hash:
-    md5: c9096a546660b9079dce531c0039e074
-    sha256: 09ef8cc587bdea80a83b6f820dbae24daadcf82be088fb0a9f6495781653e300
-  category: main
-  optional: false
-- name: types-python-dateutil
-  version: 2.8.19.20240106
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.20240106-pyhd8ed1ab_0.conda
-  hash:
-    md5: c9096a546660b9079dce531c0039e074
-    sha256: 09ef8cc587bdea80a83b6f820dbae24daadcf82be088fb0a9f6495781653e300
-  category: main
-  optional: false
-- name: types-python-dateutil
-  version: 2.8.19.20240106
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/types-python-dateutil-2.8.19.20240106-pyhd8ed1ab_0.conda
-  hash:
-    md5: c9096a546660b9079dce531c0039e074
-    sha256: 09ef8cc587bdea80a83b6f820dbae24daadcf82be088fb0a9f6495781653e300
-  category: main
-  optional: false
-- name: typing-extensions
-  version: 4.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    typing_extensions: 4.9.0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
-  hash:
-    md5: c16524c1b7227dc80b36b4fa6f77cc86
-    sha256: d795c1eb1db4ea147f01ece74e5a504d7c2e8d5ee8c11ec987884967dd938f9c
-  category: main
-  optional: false
-- name: typing-extensions
-  version: 4.9.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    typing_extensions: 4.9.0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
-  hash:
-    md5: c16524c1b7227dc80b36b4fa6f77cc86
-    sha256: d795c1eb1db4ea147f01ece74e5a504d7c2e8d5ee8c11ec987884967dd938f9c
-  category: main
-  optional: false
-- name: typing-extensions
-  version: 4.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    typing_extensions: 4.9.0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
-  hash:
-    md5: c16524c1b7227dc80b36b4fa6f77cc86
-    sha256: d795c1eb1db4ea147f01ece74e5a504d7c2e8d5ee8c11ec987884967dd938f9c
-  category: main
-  optional: false
-- name: typing-extensions
-  version: 4.9.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    typing_extensions: 4.9.0
-  url: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.9.0-hd8ed1ab_0.conda
-  hash:
-    md5: c16524c1b7227dc80b36b4fa6f77cc86
-    sha256: d795c1eb1db4ea147f01ece74e5a504d7c2e8d5ee8c11ec987884967dd938f9c
-  category: main
-  optional: false
-- name: typing_extensions
-  version: 4.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
-  hash:
-    md5: a92a6440c3fe7052d63244f3aba2a4a7
-    sha256: f3c5be8673bfd905c4665efcb27fa50192f24f84fa8eff2f19cba5d09753d905
-  category: main
-  optional: false
-- name: typing_extensions
-  version: 4.9.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
-  hash:
-    md5: a92a6440c3fe7052d63244f3aba2a4a7
-    sha256: f3c5be8673bfd905c4665efcb27fa50192f24f84fa8eff2f19cba5d09753d905
-  category: main
-  optional: false
-- name: typing_extensions
-  version: 4.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
-  hash:
-    md5: a92a6440c3fe7052d63244f3aba2a4a7
-    sha256: f3c5be8673bfd905c4665efcb27fa50192f24f84fa8eff2f19cba5d09753d905
-  category: main
-  optional: false
-- name: typing_extensions
-  version: 4.9.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.9.0-pyha770c72_0.conda
-  hash:
-    md5: a92a6440c3fe7052d63244f3aba2a4a7
-    sha256: f3c5be8673bfd905c4665efcb27fa50192f24f84fa8eff2f19cba5d09753d905
-  category: main
-  optional: false
-- name: typing_utils
-  version: 0.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: eb67e3cace64c66233e2d35949e20f92
-    sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
-  category: main
-  optional: false
-- name: typing_utils
-  version: 0.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: eb67e3cace64c66233e2d35949e20f92
-    sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
-  category: main
-  optional: false
-- name: typing_utils
-  version: 0.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: eb67e3cace64c66233e2d35949e20f92
-    sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
-  category: main
-  optional: false
-- name: typing_utils
-  version: 0.1.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/typing_utils-0.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: eb67e3cace64c66233e2d35949e20f92
-    sha256: 9e3758b620397f56fb709f796969de436d63b7117897159619b87938e1f78739
   category: main
   optional: false
 - name: tzcode
@@ -17959,54 +14546,6 @@ package:
   hash:
     md5: 5baf4efbca923cdf73490c62cc7de1e2
     sha256: 7b5ccea54cac81bda2704e1c4cf06dba17dd683871e785fa11a1788ed289be9a
-  category: main
-  optional: false
-- name: uri-template
-  version: 1.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0944dc65cb4a9b5b68522c3bb585d41c
-    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
-  category: main
-  optional: false
-- name: uri-template
-  version: 1.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0944dc65cb4a9b5b68522c3bb585d41c
-    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
-  category: main
-  optional: false
-- name: uri-template
-  version: 1.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0944dc65cb4a9b5b68522c3bb585d41c
-    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
-  category: main
-  optional: false
-- name: uri-template
-  version: 1.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/uri-template-1.3.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 0944dc65cb4a9b5b68522c3bb585d41c
-    sha256: b76904b53721dc88a46352324c79d2b077c2f74a9f7208ad2c4249892669ae94
   category: main
   optional: false
 - name: uriparser
@@ -18152,198 +14691,6 @@ package:
     sha256: a2fec221f361d6263c117f4ea6d772b21c90a2f8edc6f3eb0eadec6bfe8843db
   category: main
   optional: false
-- name: wcwidth
-  version: 0.2.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  category: main
-  optional: false
-- name: wcwidth
-  version: 0.2.13
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  category: main
-  optional: false
-- name: wcwidth
-  version: 0.2.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  category: main
-  optional: false
-- name: wcwidth
-  version: 0.2.13
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 68f0738df502a14213624b288c60c9ad
-    sha256: b6cd2fee7e728e620ec736d8dfee29c6c9e2adbd4e695a31f1d8f834a83e57e3
-  category: main
-  optional: false
-- name: webcolors
-  version: '1.13'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 166212fe82dad8735550030488a01d03
-    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
-  category: main
-  optional: false
-- name: webcolors
-  version: '1.13'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 166212fe82dad8735550030488a01d03
-    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
-  category: main
-  optional: false
-- name: webcolors
-  version: '1.13'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 166212fe82dad8735550030488a01d03
-    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
-  category: main
-  optional: false
-- name: webcolors
-  version: '1.13'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/webcolors-1.13-pyhd8ed1ab_0.conda
-  hash:
-    md5: 166212fe82dad8735550030488a01d03
-    sha256: 6e097d5fe92849ad3af2c2a313771ad2fbf1cadd4dc4afd552303b2bf3f85211
-  category: main
-  optional: false
-- name: webencodings
-  version: 0.5.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
-  category: main
-  optional: false
-- name: webencodings
-  version: 0.5.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
-  category: main
-  optional: false
-- name: webencodings
-  version: 0.5.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
-  category: main
-  optional: false
-- name: webencodings
-  version: 0.5.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=2.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/webencodings-0.5.1-pyhd8ed1ab_2.conda
-  hash:
-    md5: daf5160ff9cde3a468556965329085b9
-    sha256: 2adf9bd5482802837bc8814cbe28d7b2a4cbd2e2c52e381329eaa283b3ed1944
-  category: main
-  optional: false
-- name: websocket-client
-  version: 1.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 50ad31e07d706aae88b14a4ac9c73f23
-    sha256: d9b537d5b7c5aa7a02a4ce4c6b755e458bd8083b67752a73c92d113ccec6c10f
-  category: main
-  optional: false
-- name: websocket-client
-  version: 1.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 50ad31e07d706aae88b14a4ac9c73f23
-    sha256: d9b537d5b7c5aa7a02a4ce4c6b755e458bd8083b67752a73c92d113ccec6c10f
-  category: main
-  optional: false
-- name: websocket-client
-  version: 1.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 50ad31e07d706aae88b14a4ac9c73f23
-    sha256: d9b537d5b7c5aa7a02a4ce4c6b755e458bd8083b67752a73c92d113ccec6c10f
-  category: main
-  optional: false
-- name: websocket-client
-  version: 1.7.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/websocket-client-1.7.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 50ad31e07d706aae88b14a4ac9c73f23
-    sha256: d9b537d5b7c5aa7a02a4ce4c6b755e458bd8083b67752a73c92d113ccec6c10f
-  category: main
-  optional: false
 - name: wheel
   version: 0.42.0
   manager: conda
@@ -18453,17 +14800,6 @@ package:
     sha256: a11ae693a0645bf6c7b8a47bac030be9c0967d0b1924537b9ff7458e832c0511
   category: main
   optional: false
-- name: winpty
-  version: 0.4.3
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/winpty-0.4.3-4.tar.bz2
-  hash:
-    md5: 1cee351bf20b830d991dbe0bc8cd7dfe
-    sha256: 9df10c5b607dd30e05ba08cbd940009305c75db242476f4e845ea06008b0a283
-  category: main
-  optional: false
 - name: xerces-c
   version: 3.2.5
   manager: conda
@@ -18520,31 +14856,6 @@ package:
   hash:
     md5: b1e07902b6bb7833db8cc4ec32f32dc7
     sha256: 21328b0442f2f86ad5bf14481ed60f56a8ebb765a68d158a57ec6f32eb55762b
-  category: main
-  optional: false
-- name: xorg-fixesproto
-  version: '5.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-xextproto: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-fixesproto-5.0-h7f98852_1002.tar.bz2
-  hash:
-    md5: 65ad6e1eb4aed2b0611855aff05e04f6
-    sha256: 5d2af1b40f82128221bace9466565eca87c97726bb80bbfcd03871813f3e1876
-  category: main
-  optional: false
-- name: xorg-inputproto
-  version: 2.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-inputproto-2.3.2-h7f98852_1002.tar.bz2
-  hash:
-    md5: bcd1b3396ec6960cbc1d2855a9e60b2b
-    sha256: 6c8c2803de0f643f8bad16ece3f9a7259e4a49247543239c182d66d5e3a129a7
   category: main
   optional: false
 - name: xorg-kbproto
@@ -18708,36 +15019,6 @@ package:
     sha256: 73e5cfbdff41ef8a844441f884412aa5a585a0f0632ec901da035a03e1fe1249
   category: main
   optional: false
-- name: xorg-libxfixes
-  version: 5.0.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-fixesproto: ''
-    xorg-libx11: '>=1.7.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-5.0.3-h7f98852_1004.tar.bz2
-  hash:
-    md5: e9a21aa4d5e3e5f1aed71e8cefd46b6a
-    sha256: 1e426a1abb774ef1dcf741945ed5c42ad12ea2dc7aeed7682d293879c3e1e4c3
-  category: main
-  optional: false
-- name: xorg-libxi
-  version: 1.7.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.3.0'
-    xorg-inputproto: ''
-    xorg-libx11: '>=1.7.0,<2.0a0'
-    xorg-libxext: 1.3.*
-    xorg-libxfixes: 5.0.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.7.10-h7f98852_0.tar.bz2
-  hash:
-    md5: e77615e5141cad5a2acaa043d1cf0ca5
-    sha256: 745c1284a96b4282fe6fe122b2643e1e8c26a7ff40b733a8f4b61357238c4e68
-  category: main
-  optional: false
 - name: xorg-libxrender
   version: 0.9.11
   manager: conda
@@ -18881,158 +15162,6 @@ package:
   hash:
     md5: 515d77642eaa3639413c6b1bc3f94219
     sha256: 54d9778f75a02723784dc63aff4126ff6e6749ba21d11a6d03c1f4775f269fe0
-  category: main
-  optional: false
-- name: yaml
-  version: 0.2.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=9.4.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
-  hash:
-    md5: 4cb3ad778ec2d5a7acbdf254eb1c42ae
-    sha256: a4e34c710eeb26945bdbdaba82d3d74f60a78f54a874ec10d373811a5d217535
-  category: main
-  optional: false
-- name: yaml
-  version: 0.2.5
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h0d85af4_2.tar.bz2
-  hash:
-    md5: d7e08fcf8259d742156188e8762b4d20
-    sha256: 5301417e2c8dea45b401ffee8df3957d2447d4ce80c83c5ff151fc6bfe1c4148
-  category: main
-  optional: false
-- name: yaml
-  version: 0.2.5
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
-  hash:
-    md5: 4bb3f014845110883a3c5ee811fd84b4
-    sha256: 93181a04ba8cfecfdfb162fc958436d868cc37db504c58078eab4c1a3e57fbb7
-  category: main
-  optional: false
-- name: yaml
-  version: 0.2.5
-  manager: conda
-  platform: win-64
-  dependencies:
-    vc: '>=14.1,<15.0a0'
-    vs2015_runtime: '>=14.16.27012'
-  url: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h8ffe710_2.tar.bz2
-  hash:
-    md5: adbfb9f45d1004a26763652246a33764
-    sha256: 4e2246383003acbad9682c7c63178e2e715ad0eb84f03a8df1fbfba455dfedc5
-  category: main
-  optional: false
-- name: zeromq
-  version: 4.3.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h59595ed_0.conda
-  hash:
-    md5: 8851084c192dbc56215ac4e3c9aa30fa
-    sha256: 53bf2a18224406e9806adb3b270a2c8a028aca0c89bd40114a85d6446f5c98d1
-  category: main
-  optional: false
-- name: zeromq
-  version: 4.3.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-h93d8f39_0.conda
-  hash:
-    md5: 4c055e46b394be36681fe476c1e2ee6e
-    sha256: 19be553b3cc8352b6e842134b8de66ae39fcae80bc575c203076370faab6009c
-  category: main
-  optional: false
-- name: zeromq
-  version: 4.3.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=10.9'
-    libcxx: '>=16.0.6'
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h965bd2d_0.conda
-  hash:
-    md5: f460bbcb0ec8dc77989288fe8caa0f84
-    sha256: 06abddc92d0bf83cd9faf25f26c98d7c2cc681cb50504011580b0584cf3cb1c5
-  category: main
-  optional: false
-- name: zeromq
-  version: 4.3.5
-  manager: conda
-  platform: win-64
-  dependencies:
-    libsodium: '>=1.0.18,<1.0.19.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-h63175ca_0.conda
-  hash:
-    md5: e954e1881091405f36416f772292b396
-    sha256: f8377793c36e19da17bbb8cf517f1a969b89e1cc7cb9622dc6d60c3d1383c919
-  category: main
-  optional: false
-- name: zipp
-  version: 3.17.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  category: main
-  optional: false
-- name: zipp
-  version: 3.17.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  category: main
-  optional: false
-- name: zipp
-  version: 3.17.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
-  category: main
-  optional: false
-- name: zipp
-  version: 3.17.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/zipp-3.17.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2e4d6bc0b14e10f895fc6791a7d9b26a
-    sha256: bced1423fdbf77bca0a735187d05d9b9812d2163f60ab426fc10f11f92ecbe26
   category: main
   optional: false
 - name: zlib

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -5,7 +5,7 @@
 # available, unless you explicitly update the lock file.
 #
 # Install this environment as "YOURENV" with:
-#     conda-lock install -n YOURENV --file conda-lock.yml
+#     conda-lock install -n YOURENV conda-lock.yml
 # To update a single package to the latest version compatible with the version constraints in the source:
 #     conda-lock lock  --lockfile conda-lock.yml --update PACKAGE
 # To re-solve the entire environment, e.g. after changing a version constraint in the source file:
@@ -13,10 +13,10 @@
 version: 1
 metadata:
   content_hash:
-    linux-64: 38fe1c99ff1b56ba75ec91d9a0918051c422613997627ebf06625c60a1b5e801
-    osx-arm64: 22c4343ede0d7435b15bdf675664ec512de52ca6805131c00d48d45c2c130af0
-    osx-64: 0f802cd8b67396835b799ce46e5f9178775c5dc261d1450fea1d7e06c2463532
-    win-64: c2128af89c8dece388e933ba07be8d9f73ca543c8e57fe98f80309ac4fa46ece
+    linux-64: 5d1da888766c115bc7cb6cc75aff6957933e637ad8e498e1361f165988ff2134
+    osx-arm64: 38847c7cee2c4c5ede050eaf3d27cb4cf638bf80ff8ae4501ce67af3ee16a410
+    osx-64: 2d3855947204abafd72deb9940a43eaca8c0145fbd0639e65afad2969c9be907
+    win-64: 09cbfa4efe25fc2d36fa0665e6bf8d05ceae7046648f37c77e5fea4f45f02d08
   channels:
   - url: conda-forge
     used_env_vars: []
@@ -101,813 +101,813 @@ package:
   category: main
   optional: false
 - name: aws-c-auth
-  version: 0.7.15
+  version: 0.7.16
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-c-sdkutils: '>=0.1.14,<0.1.15.0a0'
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-c-sdkutils: '>=0.1.15,<0.1.16.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.15-h70caa3e_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.16-haed3651_8.conda
   hash:
-    md5: ac982c47c6439386e10afb4e0fe0d3e0
-    sha256: cf41dfba66b1484c9e4e852b75f1f218dbcc93d77fb3e14c8bc4a8526c65ee6f
+    md5: ce96c083829ab2727c942243ac93ffe0
+    sha256: 75a540b313e5dc212fc0a6057f8a5bee2dda443f17a5a076bd3ea4d7195d483e
   category: main
   optional: false
 - name: aws-c-auth
-  version: 0.7.15
+  version: 0.7.16
   manager: conda
   platform: osx-64
   dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-c-sdkutils: '>=0.1.14,<0.1.15.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.15-hfc9c217_0.conda
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-c-sdkutils: '>=0.1.15,<0.1.16.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.16-h9d28af5_8.conda
   hash:
-    md5: 79f9353cf289c077fe625f2ad231f434
-    sha256: 79e0eaa85281676c61de3e122d46433e53024b8d3df2a9a0ebe1099e1ea51a1e
+    md5: 0b451cddce1ea8f9247b386ba3285edc
+    sha256: f75a39577b61fc649e3a8c926b91218ebad6ea78beb2f2b16f90d3ae9493c1c4
   category: main
   optional: false
 - name: aws-c-auth
-  version: 0.7.15
+  version: 0.7.16
   manager: conda
   platform: osx-arm64
   dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-c-sdkutils: '>=0.1.14,<0.1.15.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.15-h8117f06_0.conda
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-c-sdkutils: '>=0.1.15,<0.1.16.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.16-h0d2f7a6_8.conda
   hash:
-    md5: fde7d3627a8c2b080fad5022c7609ce1
-    sha256: 20c64bb6d04c90675c0d678e23aab16db65eb99aeb51313e3696a3be8c2324dc
+    md5: a37cb159ebfb3d3adc1a351c98c1027f
+    sha256: 82006dd3067f4d09fd8cee0ea9c4836b6ac0c02db68acd001ff5c7b8669522b5
   category: main
   optional: false
 - name: aws-c-auth
-  version: 0.7.15
+  version: 0.7.16
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-c-sdkutils: '>=0.1.14,<0.1.15.0a0'
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-c-sdkutils: '>=0.1.15,<0.1.16.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.15-ha04060b_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-auth-0.7.16-h7613915_8.conda
   hash:
-    md5: 4ccf7bab3b1aac6c8a6f462222b1cb54
-    sha256: bfe53fae24d4eebb5818098ca8d1ca7952badef9e50be3494da483658a18275d
+    md5: 61c802b7e9c8d6215116c01ce7d582d9
+    sha256: 9ac4ebfc14faa7377a0df29ebf562d55e04a99d6d72f8ce8bb6a661e4753cde3
   category: main
   optional: false
 - name: aws-c-cal
-  version: 0.6.9
+  version: 0.6.10
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
     libgcc-ng: '>=12'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h14ec70c_3.conda
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.10-ha9bf9b1_2.conda
   hash:
-    md5: 7da4b84275e63f56d158d6250727a70f
-    sha256: d4f593f586378d7544900847b16d922a10c4d92aec7add6e3cb5dbe69965ab2f
+    md5: ce2471034f5459a39636aacc292c96b6
+    sha256: e45d9f1eb862f566bdea3d3229dfc74f31e647a72198fe04aab58ccc03a30a37
   category: main
   optional: false
 - name: aws-c-cal
-  version: 0.6.9
+  version: 0.6.10
   manager: conda
   platform: osx-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-he75d6b7_3.conda
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.10-hf9de6f9_2.conda
   hash:
-    md5: 56bca8b8f924ba21b26b9a0a158b93be
-    sha256: 772a3d9864658df5097c866633f14a78d88f21509157b09f9f8d6d0c04f09166
+    md5: 393dbe9973160cb09cb3594c9246e260
+    sha256: cb9b20aeec4cd037117fd0bfe2ae5a0a5f6a08a71f941be0f163bb27c87b98ea
   category: main
   optional: false
 - name: aws-c-cal
-  version: 0.6.9
+  version: 0.6.10
   manager: conda
   platform: osx-arm64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-h4fd42c2_3.conda
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.10-h677d54c_2.conda
   hash:
-    md5: c06a837ae2f0c217141c32cb408c8b92
-    sha256: dde08312c4db4e2e646e37bf5e3dc96affa0dfa87a3044821f545635cad2b440
+    md5: a501703d122cdf7cf38c1bbc8c16f981
+    sha256: d4f0fa97a3f6f5a090b0c9ed078fedf6b50f19a406d272f8e4b2b214f074323e
   category: main
   optional: false
 - name: aws-c-cal
-  version: 0.6.9
+  version: 0.6.10
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.9-hd33547d_3.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-cal-0.6.10-hf6fcf4e_2.conda
   hash:
-    md5: 7ff12aaa5c6ea3ce95fd51352750bac4
-    sha256: fee199d7848f733d44c1b9f2461016055227d0fb487a0c78a6e37ec59ee37609
+    md5: 7490ede93a75acc3589a2e43f77c79e9
+    sha256: 800b25ee5590f3ddd9186e225c756b9e5d00d3ecce8c2de5d9343af85213d883
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.12
+  version: 0.9.14
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.12-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.14-hd590300_0.conda
   hash:
-    md5: 7dbb94ffb9df66406f3101625807cac1
-    sha256: 22e7c9438f2fe3c46a1747efcaae4ab3a078714ff8992a6ec3c213f50b9d6704
+    md5: d44fe0d9a6971a4fb245be0055775d9d
+    sha256: c71dd835b1d8c7097c8d152a65680f119a203b73a6a62c5aac414bafe5e997ad
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.12
+  version: 0.9.14
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.12-h10d778d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.14-h10d778d_0.conda
   hash:
-    md5: d04b9a72861e43eb78e0c133056e1655
-    sha256: 21171720a36e233246ce9fa602b124b2fb4fffe97b906fa58bf7603d1af93789
+    md5: c620ac518f3086eaf4f105f64908a57c
+    sha256: 1d207a8aee42700763e6a7801c69721ccc06ce75e62e0e5d8fc6df0197c0a88b
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.12
+  version: 0.9.14
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.12-h93a5062_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.14-h93a5062_0.conda
   hash:
-    md5: afe8c81d8e34a96a124640788296b02e
-    sha256: 75d963943aefae31ab1a02956a5ee41c0fa347da9550bd1ce57b5cbbea7ea7e6
+    md5: 028bc18a1ef8bb1a4e4d6ec94e9b50da
+    sha256: c58aea968814459ef485c1f1aeb889423b0fa808b7c1216d96d5282ff2e796ab
   category: main
   optional: false
 - name: aws-c-common
-  version: 0.9.12
+  version: 0.9.14
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.12-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-common-0.9.14-hcfcfb64_0.conda
   hash:
-    md5: de96cbda45ce3a54ad74827e84bc7962
-    sha256: ca8994aa4ff6519e67bf4791d1eb7903a1aadceb18df9baa7136c37d0160cbe0
+    md5: 169998d49ac3c4800187bfc546e1d165
+    sha256: 46f4dced6c9d553d65e6f721d51ef43e6a343487a3073299c03a073161d7637f
   category: main
   optional: false
 - name: aws-c-compression
-  version: 0.2.17
+  version: 0.2.18
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h572eabf_8.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.18-h4466546_2.conda
   hash:
-    md5: cc6630010cb1211cc15fb348f7c7eb70
-    sha256: 0627434bcee61f94cf35d7719a395d4b7c9967f20bb877f1bd05868013a8a93c
+    md5: b0d9153fc7cfa8dc36b8703e1a59f5f3
+    sha256: 7fcc6a924691f9de65c82fd559cb1cb2ebd121c42da544a9a43623d69a284e23
   category: main
   optional: false
 - name: aws-c-compression
-  version: 0.2.17
+  version: 0.2.18
   manager: conda
   platform: osx-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-h45babc2_8.conda
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.18-h905ab21_2.conda
   hash:
-    md5: 3b63d41977e0e390e42446372f5f1b03
-    sha256: 19d3fb58b89ad3c1a2693ea81f98bca51843c7cdec7afaebc96b5013d73b2a91
+    md5: ffd7cfb55b1aa4e3eef477583b1ad87d
+    sha256: 021cee135f0d9b58fbc8d212618cd9bd6bd0012da41a6469edf010b2853dd3ef
   category: main
   optional: false
 - name: aws-c-compression
-  version: 0.2.17
+  version: 0.2.18
   manager: conda
   platform: osx-arm64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-h4fd42c2_8.conda
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.18-h677d54c_2.conda
   hash:
-    md5: c9b738b496c34db0d27b42491eb16c23
-    sha256: 0500a040f6d2838af312c26fbea6ed2a9cac54d8a74347a9c1964af8f57ff033
+    md5: 71e953c1c0fac25dd5d65d63d47389d8
+    sha256: bbc73d8ec3d760d528f15edad66835d1fe63a035f254e760235e745cf360de20
   category: main
   optional: false
 - name: aws-c-compression
-  version: 0.2.17
+  version: 0.2.18
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.17-hd33547d_8.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-compression-0.2.18-hf6fcf4e_2.conda
   hash:
-    md5: 7bfeb421dbad97271758095d204f2008
-    sha256: 1c10fa2157a5c7af38688a129460156546cc227daee7d696f9e44e6c32a2f83a
+    md5: 6efdf7af73d7043a00394a2f1b039650
+    sha256: ecb5ab2353c4499311fe17c82210955a498526c9563861777b3b0cd6dcc5cfea
   category: main
   optional: false
 - name: aws-c-event-stream
-  version: 0.4.1
+  version: 0.4.2
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.1-h17cd1f3_5.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.4.2-he635cd5_6.conda
   hash:
-    md5: 65d1aabc7656d7c08585efd584332235
-    sha256: 4cecf7af18d757fa36872a2ed8fc12b24555b87ca47844dd11669199b062b91d
+    md5: 58fc78e523e35a08423c913751a51fde
+    sha256: 38a30beabafc1dd86c0264b6746315a1010e541a1b3ed7f97e1702873e5eaa51
   category: main
   optional: false
 - name: aws-c-event-stream
-  version: 0.4.1
+  version: 0.4.2
   manager: conda
   platform: osx-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    libcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.1-h725fa68_5.conda
-  hash:
-    md5: 3a419a70c578b45e85905bbc543626d7
-    sha256: 6f031ec29e205d9f1e4787a7e23d48093121daafe45645c9fabd49803998fa86
-  category: main
-  optional: false
-- name: aws-c-event-stream
-  version: 0.4.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    libcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.1-hf6cc7c5_5.conda
-  hash:
-    md5: f7961cf04fa30ab72834dcef2bcdc72e
-    sha256: a63b54574d0a73b657ff7337d1f89bc0e5aed295d523f35c61ab193307f63df3
-  category: main
-  optional: false
-- name: aws-c-event-stream
-  version: 0.4.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.1-hf127292_5.conda
-  hash:
-    md5: 9462bb7fbe1721f6c0c3341281c3158c
-    sha256: e92109308e2f7558304f1fed31de3767efa3a7e174ba32583ae99aa7f45032fc
-  category: main
-  optional: false
-- name: aws-c-http
-  version: 0.8.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.0-hc6da83f_5.conda
-  hash:
-    md5: a257c3335609a22036947f99a87ca024
-    sha256: 0524523bec0bef2b367064c7069f88eaf4dc4945d353cdf1ef84e152d1e5e19a
-  category: main
-  optional: false
-- name: aws-c-http
-  version: 0.8.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.0-heddac68_5.conda
-  hash:
-    md5: 479f58d5d7914e2652855a2c62dac07d
-    sha256: 165e0c38633f2044536b8779065760df5cce8cfe1efa5bb5bf115abb031d0039
-  category: main
-  optional: false
-- name: aws-c-http
-  version: 0.8.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.0-hf1748bb_5.conda
-  hash:
-    md5: f82039f5c0a3a384dbbaeb64474a5c55
-    sha256: 4a88c61c6c5326828a6144b994e7c0b0ec7d58f51452b348f0dcecfae77421d2
-  category: main
-  optional: false
-- name: aws-c-http
-  version: 0.8.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-compression: '>=0.2.17,<0.2.18.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.0-h0cc4be6_5.conda
-  hash:
-    md5: 9cde958dea36567da2872c39a2669b76
-    sha256: 39444a642f1ed2a0098b92cac4593d8ab33819183744d6af5d56e7451803375f
-  category: main
-  optional: false
-- name: aws-c-io
-  version: 0.14.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    libgcc-ng: '>=12'
-    s2n: '>=1.4.3,<1.4.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.3-h3c8c088_1.conda
-  hash:
-    md5: 12af79204e13550614bc51bb380c32e5
-    sha256: 15f0162ce092aec4363eddf4068cfa198ead3f32249d7bd67f4fb0989a0f81aa
-  category: main
-  optional: false
-- name: aws-c-io
-  version: 0.14.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.3-h49ca7b5_1.conda
-  hash:
-    md5: dcf126275d061c488898f2399d7e24f3
-    sha256: 07eb4cf064c6aac55162917c49d8d1985fd35a1622da71654a1da7075c6f407a
-  category: main
-  optional: false
-- name: aws-c-io
-  version: 0.14.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.3-h8daa835_1.conda
-  hash:
-    md5: 455d2e4b89e30c28c6023491fc0a9ccf
-    sha256: 12e6743b0ea26a950a2039123dcdb2ff21d8330e1d2ee382155139a9b8a10ba6
-  category: main
-  optional: false
-- name: aws-c-io
-  version: 0.14.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.3-hf372335_1.conda
-  hash:
-    md5: f903e901692d4104ea7a68b10239f519
-    sha256: 710b8e278605944b01ea8e5551e6f17bae63e7ca7561c265ac87c21483324d0c
-  category: main
-  optional: false
-- name: aws-c-mqtt
-  version: 0.10.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.1-h0ef3971_3.conda
-  hash:
-    md5: 5f80f11865fad4cc684f1007170df6ec
-    sha256: 3ef6d24924308ed8ea9c0d3201cde18aa36fb2f8c5a79b09cdc31944424bb6f8
-  category: main
-  optional: false
-- name: aws-c-mqtt
-  version: 0.10.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.1-hcdc93dc_3.conda
-  hash:
-    md5: 1dc5c6a6c28f28c17d98a2db850eaecb
-    sha256: ffc9f373fc5482259e6b616c0814edecd74c7f4c008495b74a7a2bd7619d8b4d
-  category: main
-  optional: false
-- name: aws-c-mqtt
-  version: 0.10.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.1-h7f0f801_3.conda
-  hash:
-    md5: 97436e96a3ab245df1c2610672ea8db5
-    sha256: 0865312673162e2c44a7d2f42e68b145bf83c33d7cfd3b73a7b8d39c0402f6ba
-  category: main
-  optional: false
-- name: aws-c-mqtt
-  version: 0.10.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.1-h189e261_3.conda
-  hash:
-    md5: ad334269c08c41575be9dda1956f7a06
-    sha256: 5c963b0f806235ee661149ac3a516a43a4c83fc0f48674c6cfe3da58dec5e2c7
-  category: main
-  optional: false
-- name: aws-c-s3
-  version: 0.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-auth: '>=0.7.15,<0.7.16.0a0'
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    libgcc-ng: '>=12'
-    openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.5.0-h1b46bed_2.conda
-  hash:
-    md5: cbbdaaec72d302636a64a3fcaa3a72c7
-    sha256: 48924ea5282d6ac8481eb9cfb3b370d77746c932920cfaa7ee090ab81f25f32e
-  category: main
-  optional: false
-- name: aws-c-s3
-  version: 0.5.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    aws-c-auth: '>=0.7.15,<0.7.16.0a0'
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.5.0-h04e2de8_2.conda
-  hash:
-    md5: d4a246c2ba4da1e2903c24d3591de5e5
-    sha256: 79065c5e9a23f9a1284ecdd4f5b169528de99002b569f67e2f5a0386439e9345
-  category: main
-  optional: false
-- name: aws-c-s3
-  version: 0.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    aws-c-auth: '>=0.7.15,<0.7.16.0a0'
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.5.0-hbb97ff1_2.conda
-  hash:
-    md5: 1280957e82a26f87449e298279a3ed47
-    sha256: 1f9ced97a9db3faa1a4000728c97deb1b7aff61c2479007f6378a2abbb8dfb32
-  category: main
-  optional: false
-- name: aws-c-s3
-  version: 0.5.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    aws-c-auth: '>=0.7.15,<0.7.16.0a0'
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.5.0-h582d114_2.conda
-  hash:
-    md5: a4e4cbf2682c90361d1d41746dea4a06
-    sha256: 5e5ba602345afb829118b0c05729fb1ebebe801bc905e6ae659852082ecbfb54
-  category: main
-  optional: false
-- name: aws-c-sdkutils
-  version: 0.1.14
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.14-h572eabf_0.conda
-  hash:
-    md5: 42db61eee93a2c0f918d18bd4422d331
-    sha256: 5e9ee515fc99105a92938cd28f9229c1abb38d8afb6ec223cfbeee0f9082ebd8
-  category: main
-  optional: false
-- name: aws-c-sdkutils
-  version: 0.1.14
-  manager: conda
-  platform: osx-64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.14-h45babc2_0.conda
-  hash:
-    md5: 7605efd7c37ce3b6c0eaae86878a495c
-    sha256: 6873854003b70b79be2945ab5e6ffed9a8d40e955ce1c8479e1e907fd66eaade
-  category: main
-  optional: false
-- name: aws-c-sdkutils
-  version: 0.1.14
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.14-h4fd42c2_0.conda
-  hash:
-    md5: 92386b4cb3bee39dc69236593c2b8acb
-    sha256: 1684522b3d3459b459f5e9b3e54e702b428d28a9450a962f0f0fc90d4ccb749b
-  category: main
-  optional: false
-- name: aws-c-sdkutils
-  version: 0.1.14
-  manager: conda
-  platform: win-64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.14-hd33547d_0.conda
-  hash:
-    md5: 74ba3b20e2efe19d303c8fee39d0845a
-    sha256: 2b15548397cb5d523a2423805efbaa06b8c45478dd6e9685ba0e7be49b4335da
-  category: main
-  optional: false
-- name: aws-checksums
-  version: 0.1.17
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h572eabf_7.conda
-  hash:
-    md5: f7323eedc2685a24661cd6b57d7ed321
-    sha256: c29ca126f9dd520cc749e8cb99b07168badb333b4b1b95577bb1788c432fe2d0
-  category: main
-  optional: false
-- name: aws-checksums
-  version: 0.1.17
-  manager: conda
-  platform: osx-64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-h45babc2_7.conda
-  hash:
-    md5: 356e6abc54e4a2e26027d179ddad29ce
-    sha256: 9f6e240ce66f3d120b6bc7d6ac9f3625c039a2f0b4132479ccc9798d08200e8f
-  category: main
-  optional: false
-- name: aws-checksums
-  version: 0.1.17
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-h4fd42c2_7.conda
-  hash:
-    md5: 22e536282755e9e87ff48c652c9eec7b
-    sha256: 92a00157c3e3f387d0ba171bcbb6516893ea16fc34c34f535dd74ae38fb3db8e
-  category: main
-  optional: false
-- name: aws-checksums
-  version: 0.1.17
-  manager: conda
-  platform: win-64
-  dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.17-hd33547d_7.conda
-  hash:
-    md5: 65f9f413f9d90b3e5a34c87ffe358f73
-    sha256: f80c0c56140a28c3516b5de36b73d5ded203ecd1b3504f44ff012698f62042f9
-  category: main
-  optional: false
-- name: aws-crt-cpp
-  version: 0.26.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    aws-c-auth: '>=0.7.15,<0.7.16.0a0'
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-c-mqtt: '>=0.10.1,<0.10.2.0a0'
-    aws-c-s3: '>=0.5.0,<0.5.1.0a0'
-    aws-c-sdkutils: '>=0.1.14,<0.1.15.0a0'
-    libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.1-h33f84b2_9.conda
-  hash:
-    md5: feff02dd51629ad703677c28eaf03a1e
-    sha256: b2fac52808753136a6f17274f0bd63a5dfe9a4278e1a35749cb288a650560949
-  category: main
-  optional: false
-- name: aws-crt-cpp
-  version: 0.26.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    aws-c-auth: '>=0.7.15,<0.7.16.0a0'
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-c-mqtt: '>=0.10.1,<0.10.2.0a0'
-    aws-c-s3: '>=0.5.0,<0.5.1.0a0'
-    aws-c-sdkutils: '>=0.1.14,<0.1.15.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
     libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.1-h7fdfd8c_9.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.4.2-h30f2259_6.conda
   hash:
-    md5: 1fa198953547cb20b320e46f05441f94
-    sha256: c9fc648d81ca75336dfda7ad2c063ddf02dba4ff58638429b94ac09670ba1de2
+    md5: 0923a8e81839b0b2d9787d85d635b196
+    sha256: 65ea5552f7a87783b75a3ecf6e4acd2aee5357c4275a9932d732ee516acab0a9
   category: main
   optional: false
-- name: aws-crt-cpp
-  version: 0.26.1
+- name: aws-c-event-stream
+  version: 0.4.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    aws-c-auth: '>=0.7.15,<0.7.16.0a0'
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-c-mqtt: '>=0.10.1,<0.10.2.0a0'
-    aws-c-s3: '>=0.5.0,<0.5.1.0a0'
-    aws-c-sdkutils: '>=0.1.14,<0.1.15.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
     libcxx: '>=16'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.1-h9b04f48_9.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.4.2-h59ac3ca_6.conda
   hash:
-    md5: b2a0fc7aabfea5a7928a7ed62bfce4ba
-    sha256: 4ce5340cc166a472d245d58aa8c39ce8ac6c50c52cda94bb1c719ac15ab8fe0a
+    md5: 7278d0ef10644f95a2dd619b9917e8a2
+    sha256: 86db342fd921f17a50cf7648b45566b2449ac1408a94c2e6cae132b876f1c17c
+  category: main
+  optional: false
+- name: aws-c-event-stream
+  version: 0.4.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-event-stream-0.4.2-h3df98b0_6.conda
+  hash:
+    md5: 80ca7e9993f6b0141ae5425a69771a9a
+    sha256: 823a4665b3d38a4078b34b6f891bd388400942a3bcbad55b4c6223c559b15de6
+  category: main
+  optional: false
+- name: aws-c-http
+  version: 0.8.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.8.1-hbfc29b2_7.conda
+  hash:
+    md5: 8476ec099649e9a6de52f7f4d916cd2a
+    sha256: 0dc5b73aa31cef3faeeb902a11f12e1244ac241f995d73e4f4e3e0c01622f7a1
+  category: main
+  optional: false
+- name: aws-c-http
+  version: 0.8.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.8.1-hce3b3da_7.conda
+  hash:
+    md5: d287122dfb77c5fa0147fdf368c86d54
+    sha256: a3e6bfd71bbc4119da1e79f2bce6094f045112c230b3fd5cc9e6ccd36aba3156
+  category: main
+  optional: false
+- name: aws-c-http
+  version: 0.8.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.8.1-hfe5d766_7.conda
+  hash:
+    md5: 4096407e9d908ef9a292980f93034fcd
+    sha256: 0a454c1280e87b4bfd3ab1d70498c5f60c62139ddcd06d1a68c39dcd81e05e75
+  category: main
+  optional: false
+- name: aws-c-http
+  version: 0.8.1
+  manager: conda
+  platform: win-64
+  dependencies:
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-compression: '>=0.2.18,<0.2.19.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-http-0.8.1-h4e3df0f_7.conda
+  hash:
+    md5: 08ba30d73686a5129f4209c25b31252a
+    sha256: 651bdcbe53630bf9665b76c18a6cb21a7b53fe347b03d88c1cb99ed0281c267e
+  category: main
+  optional: false
+- name: aws-c-io
+  version: 0.14.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    libgcc-ng: '>=12'
+    s2n: '>=1.4.8,<1.4.9.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.6-h96cd748_2.conda
+  hash:
+    md5: cbf8138080ea12e9d9d66cf7c8bee325
+    sha256: 5d7c7af98276949cee0e731ecedbd7e80135a3c3c3ea8246808ebb270732ae69
+  category: main
+  optional: false
+- name: aws-c-io
+  version: 0.14.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.6-hf76ed93_2.conda
+  hash:
+    md5: 95e1a36ee569ff79e7eeccaf0ec1fe76
+    sha256: ccb7eb57008cf89526694d5248878c6feffa9022aed0d657cb6a631b57f68026
+  category: main
+  optional: false
+- name: aws-c-io
+  version: 0.14.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.6-h9ac2cdb_2.conda
+  hash:
+    md5: dbbb487c722dba28b16aa609249ddc5e
+    sha256: d30fd6663148d4dee682c6ce2d3c58b3a161b9a4c760dd5d613ffec28b508d69
+  category: main
+  optional: false
+- name: aws-c-io
+  version: 0.14.6
+  manager: conda
+  platform: win-64
+  dependencies:
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-io-0.14.6-hf0b8b6f_2.conda
+  hash:
+    md5: e676be43454868d2520ce5fba70c78f2
+    sha256: 296fa165e91eb388c0a0ccc34bedc44c44cc1b89aab0e804b084203030b1e263
+  category: main
+  optional: false
+- name: aws-c-mqtt
+  version: 0.10.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.3-hffff1cc_2.conda
+  hash:
+    md5: 14ad8defb307e1edb293c3fc9da8648f
+    sha256: 6b2de4a0e6e907310127b1025a0030d023e1051da48ea5821dcc6db094d69ab7
+  category: main
+  optional: false
+- name: aws-c-mqtt
+  version: 0.10.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.3-ha335edc_2.conda
+  hash:
+    md5: c8bacb9a988fd8fb6b560a966c4979a8
+    sha256: 99304e5095193b937745d0ce6812d0333186a31c41a51b1e4297ddcd962824eb
+  category: main
+  optional: false
+- name: aws-c-mqtt
+  version: 0.10.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.3-hb8a1441_2.conda
+  hash:
+    md5: 26421a2d8a329048bb1a5673ce620de5
+    sha256: 344ba23eb2cd45105a09d775dd7449e17304b3930d5ff08fbc1426f0f8030b08
+  category: main
+  optional: false
+- name: aws-c-mqtt
+  version: 0.10.3
+  manager: conda
+  platform: win-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-mqtt-0.10.3-h96fac68_2.conda
+  hash:
+    md5: 463c0be9e1fb416192174156f58bb2af
+    sha256: 70b62dcf6314a9e1f514fe6f838eb02dfc4a28f4d17723768211a60c28c3429b
+  category: main
+  optional: false
+- name: aws-c-s3
+  version: 0.5.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-auth: '>=0.7.16,<0.7.17.0a0'
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
+    libgcc-ng: '>=12'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.5.5-h4893938_0.conda
+  hash:
+    md5: 0086628487f8888df34f024a0a0d0289
+    sha256: fef9c9a628f4f18b509a79bab6e9356724c957058464af5624757cc8c6f0536e
+  category: main
+  optional: false
+- name: aws-c-s3
+  version: 0.5.5
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-auth: '>=0.7.16,<0.7.17.0a0'
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.5.5-h6f42f56_0.conda
+  hash:
+    md5: 868fbd186bc64457777c705162fd0d88
+    sha256: a8cbf29cd471db62b42c0191411d66e446f3454dbb2d5daebd07bee670c1688d
+  category: main
+  optional: false
+- name: aws-c-s3
+  version: 0.5.5
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aws-c-auth: '>=0.7.16,<0.7.17.0a0'
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.5.5-h4398043_0.conda
+  hash:
+    md5: 6a217eea9d2c78f84a23b82f0f30964a
+    sha256: 5f77bb2429760b9d2d3dd35d7a4d79883680863e4312eac99863e3d436ddcaf5
+  category: main
+  optional: false
+- name: aws-c-s3
+  version: 0.5.4
+  manager: conda
+  platform: win-64
+  dependencies:
+    aws-c-auth: '>=0.7.16,<0.7.17.0a0'
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-s3-0.5.4-h08df315_0.conda
+  hash:
+    md5: b5be2ad8a8deca436576d8aee41ecb51
+    sha256: 504ac959605e3798aba0846cce0640a6c26f15652c08b35efc7bac4cbf39ca26
+  category: main
+  optional: false
+- name: aws-c-sdkutils
+  version: 0.1.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.15-h4466546_2.conda
+  hash:
+    md5: 258194cedccd33fd8a7b95a8aa105015
+    sha256: 349a05cf5fbcb3f6f358fc05098b210aa7da4ec3ab6d4719c79bb93b50a629f8
+  category: main
+  optional: false
+- name: aws-c-sdkutils
+  version: 0.1.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.15-h905ab21_2.conda
+  hash:
+    md5: bb1523b7de7ac6f112b1992cfcfb250b
+    sha256: 77f58ac3aec0cd987f80e202a8197e123beb13b9b25b0137dd921c7a6ddc86ac
+  category: main
+  optional: false
+- name: aws-c-sdkutils
+  version: 0.1.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.15-h677d54c_2.conda
+  hash:
+    md5: a68e269534f50d5a94107b9b9b6be747
+    sha256: 02649707625df0c8908fd807f5d599b5f60b90d7b4e0e71953ff10b9aa0f010c
+  category: main
+  optional: false
+- name: aws-c-sdkutils
+  version: 0.1.15
+  manager: conda
+  platform: win-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-c-sdkutils-0.1.15-hf6fcf4e_2.conda
+  hash:
+    md5: 87fb9f67d4c936a704d6a23a748fad77
+    sha256: 03f361182431688732e7173f0d71e5778e0616e68d9ebf994d3ecb70483468a0
+  category: main
+  optional: false
+- name: aws-checksums
+  version: 0.1.18
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    libgcc-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.18-h4466546_2.conda
+  hash:
+    md5: 8a04fc5a5ecaba31f66904b47dcc7797
+    sha256: 9080f064f572ac1747d32b4dff30452ff44ef2df399e6ec7bf9730da1eb99bba
+  category: main
+  optional: false
+- name: aws-checksums
+  version: 0.1.18
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.18-h905ab21_2.conda
+  hash:
+    md5: f17e778398011e88d45edf58f24c18ae
+    sha256: 5760728e7320a01519bcbbae8dcd31b86e819f66c58f641b86b27ce592e5fff3
+  category: main
+  optional: false
+- name: aws-checksums
+  version: 0.1.18
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.18-h677d54c_2.conda
+  hash:
+    md5: 21b73ab89b82b17ae50d635ce675fea6
+    sha256: 3a7cc8824a23a39478e479865df20d88c12a954895fb9c8a91152cc76976183a
+  category: main
+  optional: false
+- name: aws-checksums
+  version: 0.1.18
+  manager: conda
+  platform: win-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-checksums-0.1.18-hf6fcf4e_2.conda
+  hash:
+    md5: ffa6601a628ccc6ec5eddb0def2db1d2
+    sha256: 1a67c0ee80cb2d18bd7cfc9ec1aae2ad78d51adc7ac9442ec70e370bbcef24de
   category: main
   optional: false
 - name: aws-crt-cpp
-  version: 0.26.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    aws-c-auth: '>=0.7.15,<0.7.16.0a0'
-    aws-c-cal: '>=0.6.9,<0.6.10.0a0'
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
-    aws-c-http: '>=0.8.0,<0.8.1.0a0'
-    aws-c-io: '>=0.14.3,<0.14.4.0a0'
-    aws-c-mqtt: '>=0.10.1,<0.10.2.0a0'
-    aws-c-s3: '>=0.5.0,<0.5.1.0a0'
-    aws-c-sdkutils: '>=0.1.14,<0.1.15.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.1-he292853_9.conda
-  hash:
-    md5: 87f5ff668914300698910967ee3e1272
-    sha256: 8480414b2b254f68b27151280d922592f38be0647d45262669684af2aa6072a9
-  category: main
-  optional: false
-- name: aws-sdk-cpp
-  version: 1.11.242
+  version: 0.26.4
   manager: conda
   platform: linux-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    aws-crt-cpp: '>=0.26.1,<0.26.2.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
+    aws-c-auth: '>=0.7.16,<0.7.17.0a0'
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-c-mqtt: '>=0.10.3,<0.10.4.0a0'
+    aws-c-s3: '>=0.5.5,<0.5.6.0a0'
+    aws-c-sdkutils: '>=0.1.15,<0.1.16.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.242-h65f022c_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.26.4-h58a74b7_3.conda
   hash:
-    md5: 09b53fbd76044de441d25261840821ac
-    sha256: 0cc1cd1007879d43051284f84d98cf46491edbae5d0beed945b7823624fd5b69
+    md5: 44b522426a11ab2afbd09b0746b0e4cd
+    sha256: f6734310a4b948f4e838748c793b75fac8af195819e9986ae935ef8ab2632a8a
   category: main
   optional: false
-- name: aws-sdk-cpp
-  version: 1.11.242
+- name: aws-crt-cpp
+  version: 0.26.4
   manager: conda
   platform: osx-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    aws-crt-cpp: '>=0.26.1,<0.26.2.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libcxx: '>=15'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.242-h2d1bcde_0.conda
+    aws-c-auth: '>=0.7.16,<0.7.17.0a0'
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-c-mqtt: '>=0.10.3,<0.10.4.0a0'
+    aws-c-s3: '>=0.5.5,<0.5.6.0a0'
+    aws-c-sdkutils: '>=0.1.15,<0.1.16.0a0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.26.4-h25b5da4_3.conda
   hash:
-    md5: b5c1c2951a7f5e6fca66553d80fe61c8
-    sha256: 2fc27f8fddc6ce9c72a1633ddf503df57173fe079c3759d561b159bfe072a53b
+    md5: 0bfe8548d21b566e2bd65c2fed90869e
+    sha256: 16c0d8f4d04f18e576ccf9fba2314956cd8667a0d14b1363cd627b600e87e890
   category: main
   optional: false
-- name: aws-sdk-cpp
-  version: 1.11.242
+- name: aws-crt-cpp
+  version: 0.26.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    aws-crt-cpp: '>=0.26.1,<0.26.2.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libcxx: '>=15'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.242-h26e3666_0.conda
+    aws-c-auth: '>=0.7.16,<0.7.17.0a0'
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-c-mqtt: '>=0.10.3,<0.10.4.0a0'
+    aws-c-s3: '>=0.5.5,<0.5.6.0a0'
+    aws-c-sdkutils: '>=0.1.15,<0.1.16.0a0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.26.4-ha2646ad_3.conda
   hash:
-    md5: 440b5c6602144a54c1d838ea62880d6d
-    sha256: c9f40e8bc2d36d6827725ce6aaba580c8af67c6e61d19cbd4235bbb009313552
+    md5: f68f07b3cc5737067f880e399d3e3643
+    sha256: 65a5b952deccac9eb6dd4695281a3ccc14c24cd8785dc02a164898817b62bb4e
   category: main
   optional: false
-- name: aws-sdk-cpp
-  version: 1.11.242
+- name: aws-crt-cpp
+  version: 0.26.4
   manager: conda
   platform: win-64
   dependencies:
-    aws-c-common: '>=0.9.12,<0.9.13.0a0'
-    aws-c-event-stream: '>=0.4.1,<0.4.2.0a0'
-    aws-checksums: '>=0.1.17,<0.1.18.0a0'
-    aws-crt-cpp: '>=0.26.1,<0.26.2.0a0'
+    aws-c-auth: '>=0.7.16,<0.7.17.0a0'
+    aws-c-cal: '>=0.6.10,<0.6.11.0a0'
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-c-http: '>=0.8.1,<0.8.2.0a0'
+    aws-c-io: '>=0.14.6,<0.14.7.0a0'
+    aws-c-mqtt: '>=0.10.3,<0.10.4.0a0'
+    aws-c-s3: '>=0.5.4,<0.5.5.0a0'
+    aws-c-sdkutils: '>=0.1.15,<0.1.16.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-crt-cpp-0.26.4-hbe739fa_2.conda
+  hash:
+    md5: d3e1411d214ca033fe35ded532f90ca3
+    sha256: 3cb4d1a9b6aa951f022e37144f143fdd2a22c3b2c879bceb0f1c2401590b2da2
+  category: main
+  optional: false
+- name: aws-sdk-cpp
+  version: 1.11.267
+  manager: conda
+  platform: linux-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-sdk-cpp-1.11.267-hb1af6a8_4.conda
+  hash:
+    md5: 3e735ae06073894080acd78365e78936
+    sha256: b5515e6012fc858c6dd3ccf36009470d4ab6e3ba283934809112cca2874fb185
+  category: main
+  optional: false
+- name: aws-sdk-cpp
+  version: 1.11.267
+  manager: conda
+  platform: osx-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
+    libcxx: '>=16'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-sdk-cpp-1.11.267-hd2aab46_4.conda
+  hash:
+    md5: 76c6a4d1839a71361c31d9bcce3601b7
+    sha256: ce10e38c01771663a0491a5190078484c5c3ae7be315e5b02fc1bc87e4c9856e
+  category: main
+  optional: false
+- name: aws-sdk-cpp
+  version: 1.11.267
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
+    libcxx: '>=16'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-sdk-cpp-1.11.267-ha761c4c_4.conda
+  hash:
+    md5: e8b9457ed514ea6be6c08d1d3f8f8814
+    sha256: 1d55f56449ec0c11fd56a53f4936c8cc0128bb0ad3b6f14376b396855f81f883
+  category: main
+  optional: false
+- name: aws-sdk-cpp
+  version: 1.11.267
+  manager: conda
+  platform: win-64
+  dependencies:
+    aws-c-common: '>=0.9.14,<0.9.15.0a0'
+    aws-c-event-stream: '>=0.4.2,<0.4.3.0a0'
+    aws-checksums: '>=0.1.18,<0.1.19.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.242-hf72cfbd_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/aws-sdk-cpp-1.11.267-hfaf0dd0_4.conda
   hash:
-    md5: c8b41cf62f007671504cb89a92ff2676
-    sha256: 8685e99ac1a8bf0f77df6d8d564e9f195bfd61b5098e01d723c9b044f04c3007
+    md5: d0530648ca0f77252b70ae9f8c31c0df
+    sha256: c56437510d5f2fe9d41f55809b081d79a861ba9e14c79440584bc8943f6eda76
   category: main
   optional: false
 - name: azure-core-cpp
-  version: 1.10.3
+  version: 1.11.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -915,42 +915,42 @@ package:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.10.3-h91d86a7_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-core-cpp-1.11.1-h91d86a7_1.conda
   hash:
-    md5: c05a913b8203d14b4a91c54d57b52282
-    sha256: 8740ccf0a22b13ddc7e6b0b577398fc3ec82aa8e020428aa13d69cf4c02bd0b6
+    md5: 2dbab1d281b7e1da05eee544cbdc8af6
+    sha256: 810a890bf66d6368637399ef415dcc8152acd28f4b4b61d4048b7be7cba17d4c
   category: main
   optional: false
 - name: azure-core-cpp
-  version: 1.10.3
+  version: 1.11.1
   manager: conda
   platform: osx-64
   dependencies:
     libcurl: '>=8.5.0,<9.0a0'
-    libcxx: '>=15'
+    libcxx: '>=16'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.10.3-hbb1e571_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-core-cpp-1.11.1-hbb1e571_1.conda
   hash:
-    md5: 9c258c44761c173f7b21b4375a459496
-    sha256: 9dd27a9a321ec113cd52f7e2cee268c44e31b7ce1963d34d9623d2119215652e
+    md5: 6e982efd0947cd3e9ba4223fbd988508
+    sha256: 4b22a5e01ebd7f09c869cea73ae4853fb18a10a5716c8984598327e34eb2f9da
   category: main
   optional: false
 - name: azure-core-cpp
-  version: 1.10.3
+  version: 1.11.1
   manager: conda
   platform: osx-arm64
   dependencies:
     libcurl: '>=8.5.0,<9.0a0'
-    libcxx: '>=15'
+    libcxx: '>=16'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.10.3-he231e37_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-core-cpp-1.11.1-he231e37_1.conda
   hash:
-    md5: f51b5c4b5c19c5127f0649555d841aa7
-    sha256: 94707b5b6ba45ff8de32c494d88b42dc1bde395f8bada49d4f0a170861149aec
+    md5: db465e5fc631893677ed9a603c168475
+    sha256: b923b2d25883569437b343d7223458568a235351871864e233166c0af471b731
   category: main
   optional: false
 - name: azure-core-cpp
-  version: 1.10.3
+  version: 1.11.1
   manager: conda
   platform: win-64
   dependencies:
@@ -958,10 +958,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.10.3-h249a519_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/azure-core-cpp-1.11.1-h249a519_1.conda
   hash:
-    md5: cceb803b800f0ea2c8d1f259c0a03136
-    sha256: 788b051ecbf9c8854be1ef627a654007df3a41f6dbe83d41d97d1a2f42b9a0e6
+    md5: c4d3c999a102779040815db07d1a2928
+    sha256: 5cfaed8d28aeceb700b524cff6285777de3a9a732acf7cef4994818df93301f3
   category: main
   optional: false
 - name: azure-storage-blobs-cpp
@@ -969,14 +969,14 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    azure-core-cpp: '>=1.10.3,<2.0a0'
-    azure-storage-common-cpp: '>=12.5.0,<13.0a0'
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.10.0-h00ab1b0_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-blobs-cpp-12.10.0-h00ab1b0_1.conda
   hash:
-    md5: 64eec459779f01803594f5272cdde23c
-    sha256: ea323e7028590b1877af92b76bc3cda52db5a1d90b8321ec91b9db0689f07fb3
+    md5: 1e63d3866554a4d2e3d1cba5f21a2841
+    sha256: c88f6bc72ef42fd09471d4c4b2293fa17f730e3ba10290a0bb86de0ff7e9b195
   category: main
   optional: false
 - name: azure-storage-blobs-cpp
@@ -984,14 +984,13 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    azure-core-cpp: '>=1.10.3,<2.0a0'
-    azure-storage-common-cpp: '>=12.5.0,<13.0a0'
-    libcxx: '>=16.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.10.0-he51d815_0.conda
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-blobs-cpp-12.10.0-h7728843_1.conda
   hash:
-    md5: 49b100390f08fbbf2219b4e220f79983
-    sha256: 2b20c7884bebc511a7433802a81b7fc95a9aae957a760779a1699f087ffdf018
+    md5: dc24ba551b749b6bab11e0ef22dc3438
+    sha256: 2c68d1d28bdf9d465843bdb6818868e0b0af46dafc1f4e41df0af33241707113
   category: main
   optional: false
 - name: azure-storage-blobs-cpp
@@ -999,14 +998,13 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    azure-core-cpp: '>=1.10.3,<2.0a0'
-    azure-storage-common-cpp: '>=12.5.0,<13.0a0'
-    libcxx: '>=16.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.10.0-h6aa02a4_0.conda
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-blobs-cpp-12.10.0-h2ffa867_1.conda
   hash:
-    md5: a2ae520245fd026fcbfac906c5350834
-    sha256: a85bb29ab61207489f91e239b687bb97a2bf22a09c9b0e2cf32dd003f9a4c366
+    md5: 39b3f0ae5d50a2ca0e46386611da6f65
+    sha256: 17005aa1dfbcd265ea638bc9566710a6b8c59267b7dae56b36d556f131938f0d
   category: main
   optional: false
 - name: azure-storage-blobs-cpp
@@ -1014,15 +1012,15 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    azure-core-cpp: '>=1.10.3,<2.0a0'
-    azure-storage-common-cpp: '>=12.5.0,<13.0a0'
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.10.0-h91493d7_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/azure-storage-blobs-cpp-12.10.0-h91493d7_1.conda
   hash:
-    md5: 67205642c7297f6f9d1e0d192d9a7d8a
-    sha256: 627842ff2961881a8a98fa6bc34f5d8378e4de9d492e7cf51f2646b285b6e7ad
+    md5: a542efec5e16debff638674a0fee1316
+    sha256: e3444d2331c9b40c68a8c5dc07ca3b7cc6c610ab6a23c2ca192f2f93ea5d18b9
   category: main
   optional: false
 - name: azure-storage-common-cpp
@@ -1030,15 +1028,15 @@ package:
   manager: conda
   platform: linux-64
   dependencies:
-    azure-core-cpp: '>=1.10.3,<2.0a0'
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.1,<3.0.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.5.0-hb858b4b_2.conda
+    libxml2: '>=2.12.5,<3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/azure-storage-common-cpp-12.5.0-h94269e2_4.conda
   hash:
-    md5: 19f23b45d1925a9a8f701a3f6f9cce4f
-    sha256: 68e177ae983d63323b9bd1c1528776bb0e03d5d5aef0addba97aed4537e649a6
+    md5: f364272cb4c2f4ce2341067107b82865
+    sha256: 7143e85cfadcc3c789c879e66c3e6dbf8b6d5822d1d75b5b3063955279348233
   category: main
   optional: false
 - name: azure-storage-common-cpp
@@ -1046,15 +1044,14 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    azure-core-cpp: '>=1.10.3,<2.0a0'
-    libcxx: '>=16.0.6'
-    libxml2: '>=2.12.1,<3.0.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.5.0-hf4badfb_2.conda
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    libcxx: '>=16'
+    libxml2: '>=2.12.5,<3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/azure-storage-common-cpp-12.5.0-h0e82ce4_4.conda
   hash:
-    md5: 277020b2f0245d1d5a0a3bb0e921c069
-    sha256: b9336e9cbbf7a26f5cfab7dca2aec8037549efe8c8d6022e07b38f8840bbc608
+    md5: 8a980ef5c6bc0677f5a60d5d60a4efdd
+    sha256: ecff365d3cdf3b5b04a6f823ec75b07459fb6cc312475180f7a33a237242ea27
   category: main
   optional: false
 - name: azure-storage-common-cpp
@@ -1062,15 +1059,14 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    azure-core-cpp: '>=1.10.3,<2.0a0'
-    libcxx: '>=16.0.6'
-    libxml2: '>=2.12.1,<3.0.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.5.0-h607ffeb_2.conda
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    libcxx: '>=16'
+    libxml2: '>=2.12.5,<3.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/azure-storage-common-cpp-12.5.0-h09a5875_4.conda
   hash:
-    md5: 457b5b7cfda7d6bec46e95cbe6554bc5
-    sha256: 1c020b792916289eec5b203e6cb301e80d434dc74de3ad9269ffa5b3fb9fa8c3
+    md5: 79913037a7d33c1e1246ef3fc95baf6d
+    sha256: 787ef00c1a57f2b29950854433e1f95bd3acb712bf80ec0f841145f8383b2d1e
   category: main
   optional: false
 - name: azure-storage-common-cpp
@@ -1078,14 +1074,14 @@ package:
   manager: conda
   platform: win-64
   dependencies:
-    azure-core-cpp: '>=1.10.3,<2.0a0'
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.5.0-h91493d7_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/azure-storage-common-cpp-12.5.0-h91493d7_4.conda
   hash:
-    md5: b90cc625e300c18cbd75a8f7cd880a1b
-    sha256: cd3550f2181f3b62853af292d4f2639c2d1dee139f3949621173c4699aeb30da
+    md5: 2a7ee0e1ffc37e91aa5c1d59d4aea8b8
+    sha256: 65e56d7a782db1036d4ef47aa701037fb96849247de03db874e511e8a2791cb5
   category: main
   optional: false
 - name: beautifulsoup4
@@ -1531,51 +1527,51 @@ package:
   category: main
   optional: false
 - name: c-ares
-  version: 1.26.0
+  version: 1.28.1
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.26.0-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.28.1-hd590300_0.conda
   hash:
-    md5: a86d90025198fd411845fc245ebc06c8
-    sha256: 3771589a91303710a59d1d40bbcdca43743969fe993ea576538ba375ac8ab0fa
+    md5: dcde58ff9a1f30b0037a2315d1846d1f
+    sha256: cb25063f3342149c7924b21544109696197a9d774f1407567477d4f3026bf38a
   category: main
   optional: false
 - name: c-ares
-  version: 1.26.0
+  version: 1.28.1
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.26.0-h10d778d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.28.1-h10d778d_0.conda
   hash:
-    md5: 04a8ab3d4f9a9446b286c4a90f665148
-    sha256: 4b01708ed02f3e2cf9e8919a6fc1d3116cdf84c1a771294031e880f54235f47c
+    md5: d5eb7992227254c0e9a0ce71151f0079
+    sha256: fccd7ad7e3dfa6b19352705b33eb738c4c55f79f398e106e6cf03bab9415595a
   category: main
   optional: false
 - name: c-ares
-  version: 1.26.0
+  version: 1.28.1
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.26.0-h93a5062_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.28.1-h93a5062_0.conda
   hash:
-    md5: 58b9187431de0a2ffebc907f4590e2e5
-    sha256: 1dfdbac985a74a905f2bcf62f13ce758a8356e50d4b28ddbc2027df8580717d8
+    md5: 04f776a6139f7eafc2f38668570eb7db
+    sha256: 2fc553d7a75e912efbdd6b82cd7916cc9cb2773e6cd873b77e02d631dd7be698
   category: main
   optional: false
 - name: c-ares
-  version: 1.26.0
+  version: 1.28.1
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.26.0-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/c-ares-1.28.1-hcfcfb64_0.conda
   hash:
-    md5: db4a1d40f8ac823f51450eb9da44dff0
-    sha256: 8b5a70412d441a43686f1f580d7db5886e0bc0840ccc4d3a6d3bb8c355847a3f
+    md5: 3b2a518680f790a79a7e77bad1861c3a
+    sha256: 44ded34fdac46d4a37942c1cae3fc871dc6ecb13e0408442c6f8797671b332e6
   category: main
   optional: false
 - name: ca-certificates
@@ -1829,68 +1825,68 @@ package:
   category: main
   optional: false
 - name: cfitsio
-  version: 4.3.1
+  version: 4.4.0
   manager: conda
   platform: linux-64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.4.0,<9.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
     libgcc-ng: '>=12'
     libgfortran-ng: ''
     libgfortran5: '>=12.3.0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.3.1-hbdc6101_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cfitsio-4.4.0-hbdc6101_0.conda
   hash:
-    md5: dcea02841b33a9c49f74ca9328de919a
-    sha256: b91003bff71351a0132c84d69fbb5afcfa90e57d83f76a180c6a5a0289099fb1
+    md5: 446ac3db6cb017e3dd067cc35cf51442
+    sha256: fe50510b705d2adf6f7c162293f788ee7fa2eebd33adf30856723667e6a45586
   category: main
   optional: false
 - name: cfitsio
-  version: 4.3.1
+  version: 4.4.0
   manager: conda
   platform: osx-64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.4.0,<9.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
     libgfortran: 5.*
     libgfortran5: '>=13.2.0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.3.1-h60fb419_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/cfitsio-4.4.0-h60fb419_0.conda
   hash:
-    md5: 03ab895afe3804b527c12193a9612cac
-    sha256: 5bd157478529ff4d05b8e8654de0580609177252eb11ecf5201b831effeeb2ec
+    md5: fea202fa33621a6c8a8a7146af6b34b7
+    sha256: 476c45686fd8b3309117fc5c37ce29338f6f241f2598e3506f85ca196fc41cc9
   category: main
   optional: false
 - name: cfitsio
-  version: 4.3.1
+  version: 4.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
-    libcurl: '>=8.4.0,<9.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
     libgfortran: 5.*
     libgfortran5: '>=13.2.0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.3.1-h808cd33_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cfitsio-4.4.0-h808cd33_0.conda
   hash:
-    md5: 22b61b2ad129db82da2eee76710f7551
-    sha256: 9395bd24ef552ac6063e2d6a6fc57e5c7067a74b8d8ee3f06d8389baffacf016
+    md5: b465ec19ed65afa0346d829214a92524
+    sha256: 919484b46d6afeb7109c50f216a492ab52a4db118f2fa940a03cbb80ba8a286c
   category: main
   optional: false
 - name: cfitsio
-  version: 4.3.1
+  version: 4.4.0
   manager: conda
   platform: win-64
   dependencies:
-    libcurl: '>=8.4.0,<9.0a0'
+    libcurl: '>=8.5.0,<9.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.3.1-h9b0cee5_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/cfitsio-4.4.0-h9b0cee5_0.conda
   hash:
-    md5: eb7f15f7b2160dec9e803a86dcbe1d03
-    sha256: 9fb11c689bb4c88e031c931cae23b09880e7a8c17713261844c16f5e88f349f2
+    md5: 02210be7da0ce4dddad3e566c03a0864
+    sha256: aa7f6925a289a09c0009b74b0ed67ed760e05554928336c3834e7d23e25379df
   category: main
   optional: false
 - name: charset-normalizer
@@ -2280,68 +2276,68 @@ package:
   category: main
   optional: false
 - name: cryptography
-  version: 42.0.2
+  version: 42.0.5
   manager: conda
   platform: linux-64
   dependencies:
     cffi: '>=1.12'
     libgcc-ng: '>=12'
-    openssl: '>=3.1.5,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.2-py312h4742d6a_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-42.0.5-py312h241aef2_0.conda
   hash:
-    md5: 4c0d8028965cbef03ee9e08eaed9f6cf
-    sha256: bb749d84d13de3f0fbbca90666af9458c50c195d1179c4e977959458566c24be
+    md5: 0d8c0e4e8c1b2796eaf6770a76a9d1e4
+    sha256: 5dc135fc6ea57bf94cf32313f91c93f8a4af15133879dd86e6c8c16e4e07c55e
   category: main
   optional: false
 - name: cryptography
-  version: 42.0.2
+  version: 42.0.5
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.12'
     cffi: '>=1.12'
-    openssl: '>=3.1.5,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/cryptography-42.0.2-py312h8c97cfe_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/cryptography-42.0.5-py312h3d16f4b_0.conda
   hash:
-    md5: 58835734da16ea54a5cd831efe2d5bd9
-    sha256: 317f241b435094ab57964f3256ce6eb0f05ba0fc5601311e0c046ff031eb1d4a
+    md5: 6132f6e13868c12209c823c8d193e16e
+    sha256: dcf489514a1b93981da61de21c94a35a8f6f969759cdb5a9c222bfb10bc5063e
   category: main
   optional: false
 - name: cryptography
-  version: 42.0.2
+  version: 42.0.5
   manager: conda
   platform: osx-arm64
   dependencies:
     cffi: '>=1.12'
-    openssl: '>=3.1.5,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-42.0.2-py312he87677a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-42.0.5-py312h99f8e83_0.conda
   hash:
-    md5: e44a0501d30888f3332963477acc7f98
-    sha256: 3266a03052092ce0a200da883044e60201183ce7f96ad844c5f67726f384b3e3
+    md5: 32f29561e515d2aae57275d8b7af528d
+    sha256: 6e37a83b60a85cb58224213c710b476a2a06fe48f45c1fa76b1d7a2c3ddaff0a
   category: main
   optional: false
 - name: cryptography
-  version: 42.0.2
+  version: 42.0.5
   manager: conda
   platform: win-64
   dependencies:
     cffi: '>=1.12'
-    openssl: '>=3.1.5,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/cryptography-42.0.2-py312he4c2ea2_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/cryptography-42.0.5-py312h1f4a190_0.conda
   hash:
-    md5: c51a234896448b69affb39552a594b2b
-    sha256: 668ec454a2bf672b4f606695e884fc1dd26a80a79fccaebc48e44273b8c6db26
+    md5: 14256d16d22cfbba12f0bb9e485e9077
+    sha256: 6475b53ddb2b623a34d515977704488b19bf1ef8c5a1a9004c22a739351f8588
   category: main
   optional: false
 - name: cycler
@@ -2392,486 +2388,153 @@ package:
     sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
   category: main
   optional: false
-- name: debugpy
-  version: 1.8.1
+- name: docopt
+  version: 0.6.2
   manager: conda
   platform: linux-64
   dependencies:
-    cffi: '>=1.12'
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
+  hash:
+    md5: a9ed63e45579cfef026a916af2bc27c9
+    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
+  category: main
+  optional: false
+- name: docopt
+  version: 0.6.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
+  hash:
+    md5: a9ed63e45579cfef026a916af2bc27c9
+    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
+  category: main
+  optional: false
+- name: docopt
+  version: 0.6.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
+  hash:
+    md5: a9ed63e45579cfef026a916af2bc27c9
+    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
+  category: main
+  optional: false
+- name: docopt
+  version: 0.6.2
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
+  hash:
+    md5: a9ed63e45579cfef026a916af2bc27c9
+    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
+  category: main
+  optional: false
+- name: exceptiongroup
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
+  hash:
+    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
+    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
+  category: main
+  optional: false
+- name: exceptiongroup
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
+  hash:
+    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
+    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
+  category: main
+  optional: false
+- name: exceptiongroup
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
+  hash:
+    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
+    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
+  category: main
+  optional: false
+- name: exceptiongroup
+  version: 1.2.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    python: '>=3.7'
+  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
+  hash:
+    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
+    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
+  category: main
+  optional: false
+- name: expat
+  version: 2.6.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libexpat: 2.6.2
     libgcc-ng: '>=12'
-    libstdcxx-ng: '>=12'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/debugpy-1.8.1-py312h30efb56_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.6.2-h59595ed_0.conda
   hash:
-    md5: bdd639417094ace2fb1ce10b20d68d5d
-    sha256: 8a8bd15c7a8435991649ab334816d4d64970c5b0d016f59806bc45f54f31a924
-  category: main
-  optional: false
-- name: debugpy
-  version: 1.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libcxx: '>=16'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/debugpy-1.8.1-py312hede676d_0.conda
-  hash:
-    md5: e0de4e018d6013b6c2e2ae42640fb65c
-    sha256: f957393cb09e3df00176079253e0f845ab8c87dbca3c38e1a14df21ffe9d7083
-  category: main
-  optional: false
-- name: debugpy
-  version: 1.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libcxx: '>=16'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/debugpy-1.8.1-py312h20a0b95_0.conda
-  hash:
-    md5: d850abbd9eeedbe2e734e397038f3f76
-    sha256: d8ae528ddf391511387bb4c67d7dd4ad3cb808ee9b093429379803cf58a13807
-  category: main
-  optional: false
-- name: debugpy
-  version: 1.8.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/debugpy-1.8.1-py312h53d5487_0.conda
-  hash:
-    md5: 4094ccb019f079de8b0f61a5f366d294
-    sha256: 5e8beecf42088481c88aa97118c52b2142f0e0d48ffed877e973c309c7fc83af
-  category: main
-  optional: false
-- name: cycler
-  version: 0.12.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
-  category: main
-  optional: false
-- name: cycler
-  version: 0.12.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
-  category: main
-  optional: false
-- name: cycler
-  version: 0.12.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
-  category: main
-  optional: false
-- name: cycler
-  version: 0.12.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 5cd86562580f274031ede6aa6aa24441
-    sha256: f221233f21b1d06971792d491445fd548224641af9443739b4b7b6d5d72954a8
-  category: main
-  optional: false
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
-  category: main
-  optional: false
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
-  category: main
-  optional: false
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
-  category: main
-  optional: false
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: 961b3a227b437d82ad7054484cfa71b2
-    sha256: 9717a059677553562a8f38ff07f3b9f61727bd614f505658b0a5ecbcf8df89be
-  category: main
-  optional: false
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
-  category: main
-  optional: false
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
-  category: main
-  optional: false
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
-  category: main
-  optional: false
-- name: docopt
-  version: 0.6.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/docopt-0.6.2-py_1.tar.bz2
-  hash:
-    md5: a9ed63e45579cfef026a916af2bc27c9
-    sha256: 4bbfb8ab343b4711223aedf797a2678955412124e71415dc2fe9816248f0b28d
-  category: main
-  optional: false
-- name: eccodes
-  version: 2.34.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    jasper: '>=4.2.0,<5.0a0'
-    libaec: '>=1.1.2,<2.0a0'
-    libgcc-ng: '>=12'
-    libgfortran-ng: ''
-    libgfortran5: '>=12.3.0'
-    libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
-    libstdcxx-ng: '>=12'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/eccodes-2.34.0-he84ddb8_0.conda
-  hash:
-    md5: 7bead4ebb77dc44f1b9b5d54b3aa90bd
-    sha256: 079124485c236c29f20a70f4d0028c29047dfeff6f0c5bf599912aae55c4dc2d
-  category: main
-  optional: false
-- name: eccodes
-  version: 2.34.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    jasper: '>=4.2.0,<5.0a0'
-    libaec: '>=1.1.2,<2.0a0'
-    libcxx: '>=16'
-    libgfortran: 5.*
-    libgfortran5: '>=13.2.0'
-    libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/eccodes-2.34.0-h40b907c_0.conda
-  hash:
-    md5: 432175fca4c4055424fe24f679e0ebd1
-    sha256: fe95e333019c9a69bc3292f765c770e8755fa124ffaf58bd15d77472826dab39
-  category: main
-  optional: false
-- name: eccodes
-  version: 2.34.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    jasper: '>=4.2.0,<5.0a0'
-    libaec: '>=1.1.2,<2.0a0'
-    libcxx: '>=16'
-    libgfortran: 5.*
-    libgfortran5: '>=13.2.0'
-    libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/eccodes-2.34.0-h64f3314_0.conda
-  hash:
-    md5: aa9711df3b59367e9088a138ccab31fc
-    sha256: cfb56169ac86753bb4c267a921ebd02c0e1430ad76d70203b8bdb5ec86426b92
-  category: main
-  optional: false
-- name: eccodes
-  version: 2.34.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    hdf5: '>=1.14.3,<1.14.4.0a0'
-    jasper: '>=4.2.0,<5.0a0'
-    libaec: '>=1.1.2,<2.0a0'
-    libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
-    libzlib: '>=1.2.13,<1.3.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/eccodes-2.34.0-h97caf96_0.conda
-  hash:
-    md5: 3e7689d24ed95fe17a564a603a742c5b
-    sha256: eb497a830ee5ee1103c606c1151d33e7b1c6d9db197e86d0d8bed5adb638cc72
-  category: main
-  optional: false
-- name: entrypoints
-  version: '0.4'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cf04868fee0a029769bd41f4b2fbf2d
-    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
-  category: main
-  optional: false
-- name: entrypoints
-  version: '0.4'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cf04868fee0a029769bd41f4b2fbf2d
-    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
-  category: main
-  optional: false
-- name: entrypoints
-  version: '0.4'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cf04868fee0a029769bd41f4b2fbf2d
-    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
-  category: main
-  optional: false
-- name: entrypoints
-  version: '0.4'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/entrypoints-0.4-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 3cf04868fee0a029769bd41f4b2fbf2d
-    sha256: 2ec4a0900a4a9f42615fc04d0fb3286b796abe56590e8e042f6ec25e102dd5af
-  category: main
-  optional: false
-- name: exceptiongroup
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: main
-  optional: false
-- name: exceptiongroup
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: main
-  optional: false
-- name: exceptiongroup
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
-  category: main
-  optional: false
-- name: exceptiongroup
-  version: 1.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.2.0-pyhd8ed1ab_2.conda
-  hash:
-    md5: 8d652ea2ee8eaee02ed8dc820bc794aa
-    sha256: a6ae416383bda0e3ed14eaa187c653e22bec94ff2aa3b56970cdf0032761e80d
+    md5: 53fb86322bdb89496d7579fe3f02fd61
+    sha256: 89916c536ae5b85bb8bf0cfa27d751e274ea0911f04e4a928744735c14ef5155
   category: main
   optional: false
 - name: expat
-  version: 2.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libexpat: 2.5.0
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/expat-2.5.0-hcb278e6_1.conda
-  hash:
-    md5: 8b9b5aca60558d02ddaa09d599e55920
-    sha256: 36dfeb4375059b3bba75ce9b38c29c69fd257342a79e6cf20e9f25c1523f785f
-  category: main
-  optional: false
-- name: expat
-  version: 2.5.0
+  version: 2.6.2
   manager: conda
   platform: osx-64
   dependencies:
-    libexpat: 2.5.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.5.0-hf0c8a7f_1.conda
+    libexpat: 2.6.2
+  url: https://conda.anaconda.org/conda-forge/osx-64/expat-2.6.2-h73e2aa4_0.conda
   hash:
-    md5: e12630038077877cbb6c7851e139c17c
-    sha256: 15c04a5a690b337b50fb7550cce057d843cf94dd0109d576ec9bc3448a8571d0
+    md5: dc0882915da2ec74696ad87aa2350f27
+    sha256: 0fd1befb18d9d937358a90d5b8f97ac2402761e9d4295779cbad9d7adfb47976
   category: main
   optional: false
 - name: expat
-  version: 2.5.0
+  version: 2.6.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libexpat: 2.5.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.5.0-hb7217d7_1.conda
+    libexpat: 2.6.2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/expat-2.6.2-hebf3989_0.conda
   hash:
-    md5: 624fa0dd6fdeaa650b71a62296fdfedf
-    sha256: 9f06afbe4604decf6a2e8e7e87f5ca218a3e9049d57d5b3fcd538ca6240d21a0
+    md5: de0cff0ec74f273c4b6aa281479906c3
+    sha256: 9ac22553a4d595d7e4c9ca9aa09a0b38da65314529a7a7008edc73d3f9e7904a
   category: main
   optional: false
 - name: expat
-  version: 2.5.0
+  version: 2.6.2
   manager: conda
   platform: win-64
   dependencies:
-    libexpat: 2.5.0
-  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.5.0-h63175ca_1.conda
+    libexpat: 2.6.2
+  url: https://conda.anaconda.org/conda-forge/win-64/expat-2.6.2-h63175ca_0.conda
   hash:
-    md5: 87c77fe1b445aedb5c6d207dd236fa3e
-    sha256: 3bcd88290cd462d5573c2923c796599d0dece2ff9d9c9d6c914d31e9c5881aaf
+    md5: 52f9dec6758ceb8ce0ea8af9fa13eb1a
+    sha256: f5a13d4bc591a4dc210954f492dd59a0ecf9b9d2ab28bf2ece755ca8f69ec1b4
   category: main
   optional: false
 - name: fake-useragent
   version: 1.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/fake-useragent-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 87ac838f10c54be8014803165f44b936
-    sha256: 3710af40b8d780a0ee3884340662f67c4ccd67295a536113133181a680b3e551
-  category: main
-  optional: false
-- name: fake-useragent
-  version: 1.4.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/fake-useragent-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 87ac838f10c54be8014803165f44b936
-    sha256: 3710af40b8d780a0ee3884340662f67c4ccd67295a536113133181a680b3e551
-  category: main
-  optional: false
-- name: fake-useragent
-  version: 1.4.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/fake-useragent-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 87ac838f10c54be8014803165f44b936
-    sha256: 3710af40b8d780a0ee3884340662f67c4ccd67295a536113133181a680b3e551
-  category: main
-  optional: false
-- name: fake-useragent
-  version: 1.4.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/fake-useragent-1.4.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 87ac838f10c54be8014803165f44b936
-    sha256: 3710af40b8d780a0ee3884340662f67c4ccd67295a536113133181a680b3e551
-  category: main
-  optional: false
-- name: findlibs
-  version: 0.0.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -2919,123 +2582,174 @@ package:
   category: main
   optional: false
 - name: fiona
-  version: 1.9.5
+  version: 1.9.6
   manager: conda
   platform: linux-64
   dependencies:
     attrs: '>=19.2.0'
+    certifi: ''
     click: '>=8.0,<9.dev0'
     click-plugins: '>=1.0'
     cligj: '>=0.5'
     gdal: ''
     libgcc-ng: '>=12'
-    libgdal: '>=3.8.2,<3.9.0a0'
+    libgdal: '>=3.8.4,<3.9.0a0'
     libstdcxx-ng: '>=12'
-    numpy: '>=1.26.2,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-    setuptools: ''
     shapely: ''
     six: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.9.5-py312h66d9856_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fiona-1.9.6-py312h66d9856_0.conda
   hash:
-    md5: dbc7f7adcc156b5dad33c0fd0037e5d7
-    sha256: d786c2fcbbd39c53b30e3a35ac4d77254fdacacc7eebff9457e271803b14ce14
+    md5: a7e2048665753cff7f947af55f2dddb0
+    sha256: 8b9f2377852498c97397125847a012a9efe9bca35931ca97f178c0ff190a07a9
   category: main
   optional: false
 - name: fiona
-  version: 1.9.5
+  version: 1.9.6
   manager: conda
   platform: osx-64
   dependencies:
     attrs: '>=19.2.0'
+    certifi: ''
     click: '>=8.0,<9.dev0'
     click-plugins: '>=1.0'
     cligj: '>=0.5'
     gdal: ''
+    libcxx: '>=16'
+    libgdal: '>=3.8.4,<3.9.0a0'
+    numpy: '>=1.26.4,<2.0a0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    shapely: ''
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/fiona-1.9.6-py312hc18349f_0.conda
+  hash:
+    md5: 7677246f7ad31813a4e361482abeb0ab
+    sha256: d4b9b7d3077fea8fe688da939837a768fbe91101fe6edd6fecbaacb365d05096
+  category: main
+  optional: false
+- name: fiona
+  version: 1.9.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    attrs: '>=19.2.0'
+    certifi: ''
+    click: '>=8.0,<9.dev0'
+    click-plugins: '>=1.0'
+    cligj: '>=0.5'
+    gdal: ''
+    libcxx: '>=16'
+    libgdal: '>=3.8.4,<3.9.0a0'
+    numpy: '>=1.26.4,<2.0a0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    shapely: ''
+    six: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fiona-1.9.6-py312hd158ed5_0.conda
+  hash:
+    md5: 3e593b499bfe99a1d6460fc8c7ea0d23
+    sha256: d6d972e7ce9208c55ae296016d92d596c7b6e5a10025c82d1631af3f331b4913
+  category: main
+  optional: false
+- name: fiona
+  version: 1.9.6
+  manager: conda
+  platform: win-64
+  dependencies:
+    attrs: '>=19.2.0'
+    certifi: ''
+    click: '>=8.0,<9.dev0'
+    click-plugins: '>=1.0'
+    cligj: '>=0.5'
+    gdal: ''
+    libgdal: '>=3.8.4,<3.9.0a0'
+    numpy: '>=1.26.4,<2.0a0'
+    python: '>=3.12,<3.13.0a0'
+    python_abi: 3.12.*
+    shapely: ''
+    six: ''
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/fiona-1.9.6-py312h95cbb4d_0.conda
+  hash:
+    md5: c8572c3ebc648b53a07a2f49a03039f6
+    sha256: 56018dea5019718f994314ff2f9688bac416d79b4e6aebe984f7dc50f44bf4fd
+  category: main
+  optional: false
+- name: fmt
+  version: 10.2.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/fmt-10.2.1-h00ab1b0_0.conda
+  hash:
+    md5: 35ef8bc24bd34074ebae3c943d551728
+    sha256: 7b9ba098a3661e023c3555e01554354ac4891af8f8998e85f0fcbfdac79fc0d4
+  category: main
+  optional: false
+- name: fmt
+  version: 10.2.1
+  manager: conda
+  platform: osx-64
+  dependencies:
     libcxx: '>=15'
-    libgdal: '>=3.8.2,<3.9.0a0'
-    numpy: '>=1.26.2,<2.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    setuptools: ''
-    shapely: ''
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/fiona-1.9.5-py312hc18349f_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/fmt-10.2.1-h7728843_0.conda
   hash:
-    md5: 01a412476b478c8c935919ba1b45e725
-    sha256: c79f286309f650cdb986dba82ba61b0eed94249ca0f345c7911ad5637863f74a
+    md5: ab205d53bda43d03f5c5b993ccb406b3
+    sha256: 2faeccfe2b9f7c028cf271f66757365fe43b15a1234084c16f159646a646ccbc
   category: main
   optional: false
-- name: fiona
-  version: 1.9.5
+- name: fmt
+  version: 10.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    attrs: '>=19.2.0'
-    click: '>=8.0,<9.dev0'
-    click-plugins: '>=1.0'
-    cligj: '>=0.5'
-    gdal: ''
     libcxx: '>=15'
-    libgdal: '>=3.8.2,<3.9.0a0'
-    numpy: '>=1.26.2,<2.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    setuptools: ''
-    shapely: ''
-    six: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fiona-1.9.5-py312hd158ed5_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fmt-10.2.1-h2ffa867_0.conda
   hash:
-    md5: c0df0974bca13cacce11836265eb1292
-    sha256: 716c8da1cbb8e717ee657256429bafd0f26d12e12dc0d5b2410526d33525e660
+    md5: 8cccde6755bdd787f9840f38a34b4e7d
+    sha256: 8570ae6fb7cd1179c646e2c48105e91b3ed8ba15855f12965cc5c9719753c06f
   category: main
   optional: false
-- name: fiona
-  version: 1.9.5
+- name: fmt
+  version: 10.2.1
   manager: conda
   platform: win-64
   dependencies:
-    attrs: '>=19.2.0'
-    click: '>=8.0,<9.dev0'
-    click-plugins: '>=1.0'
-    cligj: '>=0.5'
-    gdal: ''
-    libgdal: '>=3.8.2,<3.9.0a0'
-    numpy: '>=1.26.2,<2.0a0'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    setuptools: ''
-    shapely: ''
-    six: ''
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/fiona-1.9.5-py312h95cbb4d_3.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/fmt-10.2.1-h181d51b_0.conda
   hash:
-    md5: e6cba0c3b00e5d6cb0ddf7146806c38b
-    sha256: 5522d5c92740105a0a0a0c58b366845ca0b1822bd3b28e184862d7403597a8a9
+    md5: 4253b572559cc775cae49def5c97b3c0
+    sha256: 4593d75b6a1e0b5b43fdcba6b968537638a6e469521fb4c3073929f973891828
   category: main
   optional: false
 - name: folium
-  version: 0.15.1
+  version: 0.16.0
   manager: conda
   platform: linux-64
   dependencies:
-    branca: '>=0.7.0'
+    branca: '>=0.6.0'
     jinja2: '>=2.9'
     numpy: ''
     python: '>=3.7'
     requests: ''
     xyzservices: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.15.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 4fdfc338f6fb875b1078a7e20dbc99e2
-    sha256: c0730ddfaf35e39ac92b7fd07315843e7948b2ce3361d164ec1b722dd0440c2b
+    md5: cb1d2aa705a5b1f0fbdabd1beebce205
+    sha256: 9696ffafd873a40815312e9ea245a863b7796b73dd2759f93174cd65d6bf2144
   category: main
   optional: false
 - name: folium
-  version: 0.15.1
+  version: 0.16.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -3044,15 +2758,15 @@ package:
     xyzservices: ''
     python: '>=3.7'
     jinja2: '>=2.9'
-    branca: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.15.1-pyhd8ed1ab_0.conda
+    branca: '>=0.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 4fdfc338f6fb875b1078a7e20dbc99e2
-    sha256: c0730ddfaf35e39ac92b7fd07315843e7948b2ce3361d164ec1b722dd0440c2b
+    md5: cb1d2aa705a5b1f0fbdabd1beebce205
+    sha256: 9696ffafd873a40815312e9ea245a863b7796b73dd2759f93174cd65d6bf2144
   category: main
   optional: false
 - name: folium
-  version: 0.15.1
+  version: 0.16.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3061,15 +2775,15 @@ package:
     xyzservices: ''
     python: '>=3.7'
     jinja2: '>=2.9'
-    branca: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.15.1-pyhd8ed1ab_0.conda
+    branca: '>=0.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 4fdfc338f6fb875b1078a7e20dbc99e2
-    sha256: c0730ddfaf35e39ac92b7fd07315843e7948b2ce3361d164ec1b722dd0440c2b
+    md5: cb1d2aa705a5b1f0fbdabd1beebce205
+    sha256: 9696ffafd873a40815312e9ea245a863b7796b73dd2759f93174cd65d6bf2144
   category: main
   optional: false
 - name: folium
-  version: 0.15.1
+  version: 0.16.0
   manager: conda
   platform: win-64
   dependencies:
@@ -3078,11 +2792,11 @@ package:
     xyzservices: ''
     python: '>=3.7'
     jinja2: '>=2.9'
-    branca: '>=0.7.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.15.1-pyhd8ed1ab_0.conda
+    branca: '>=0.6.0'
+  url: https://conda.anaconda.org/conda-forge/noarch/folium-0.16.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 4fdfc338f6fb875b1078a7e20dbc99e2
-    sha256: c0730ddfaf35e39ac92b7fd07315843e7948b2ce3361d164ec1b722dd0440c2b
+    md5: cb1d2aa705a5b1f0fbdabd1beebce205
+    sha256: 9696ffafd873a40815312e9ea245a863b7796b73dd2759f93174cd65d6bf2144
   category: main
   optional: false
 - name: font-ttf-dejavu-sans-mono
@@ -3432,7 +3146,7 @@ package:
   category: main
   optional: false
 - name: fonttools
-  version: 4.48.1
+  version: 4.50.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -3441,14 +3155,14 @@ package:
     munkres: ''
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.48.1-py312h98912ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.50.0-py312h98912ed_0.conda
   hash:
-    md5: 4fdffe33b2c5cd70ff7eac09fff31c31
-    sha256: 2f6be5b9281a8916b3b8364a4473d7ca504e93f309db17b823e2eee65d98fa2e
+    md5: a4585049e1232d8ecb1dc5afe45d6784
+    sha256: dbeb732ccca48237d43fa716a461119836cd5b4e5881745300f25db43b2bc25f
   category: main
   optional: false
 - name: fonttools
-  version: 4.48.1
+  version: 4.50.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -3456,14 +3170,14 @@ package:
     munkres: ''
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.48.1-py312h41838bb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/fonttools-4.50.0-py312h41838bb_0.conda
   hash:
-    md5: f7db6992aa780fca60ec35fb2cfe012f
-    sha256: b4f325f595ae2eeb5c3f686e00a597a47a66adcb8dce8b982a6cbe13fa5c6925
+    md5: e685bd98318c49ce304ae304b6e6af02
+    sha256: c983db47e2de2990413f14817613b004cf837688937900a270cfef2164d9b7a2
   category: main
   optional: false
 - name: fonttools
-  version: 4.48.1
+  version: 4.50.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -3471,14 +3185,14 @@ package:
     munkres: ''
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.48.1-py312he37b823_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.50.0-py312he37b823_0.conda
   hash:
-    md5: 69f7b56ceca74d5a1af2f843d77d7f63
-    sha256: 4daffbb3b83582d6ddbc1cba6dd88876bb7aa65255c46b229619ce15f8a18c04
+    md5: ba5be50732c979473cc6b0b24d0bfda5
+    sha256: 44d8ee74106a7aa2f4c896322040edb4f2e984a66ec6a8794639f1cbde9b002e
   category: main
   optional: false
 - name: fonttools
-  version: 4.48.1
+  version: 4.50.0
   manager: conda
   platform: win-64
   dependencies:
@@ -3489,10 +3203,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.48.1-py312he70551f_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/fonttools-4.50.0-py312he70551f_0.conda
   hash:
-    md5: 19208b0c0f867d08ea95a334810193a1
-    sha256: 8ab968251cd063b00d92b6a2172861ec6b44d4ac03a50218bf6e8531358cfad7
+    md5: 47c1ab226faafab8ff5dc4e86b673183
+    sha256: 3ee86fb3b1a8f5b403570c08f8492fa0c60abfa4708beae3bb8219d52a7cab03
   category: main
   optional: false
 - name: freetype
@@ -3612,82 +3326,82 @@ package:
   category: main
   optional: false
 - name: gdal
-  version: 3.8.3
+  version: 3.8.4
   manager: conda
   platform: linux-64
   dependencies:
     hdf5: '>=1.14.3,<1.14.4.0a0'
     libgcc-ng: '>=12'
-    libgdal: 3.8.3
+    libgdal: 3.8.4
     libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.5,<3.0a0'
-    numpy: '>=1.26.3,<2.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     openssl: '>=3.2.1,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.8.3-py312h257dd4b_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.8.4-py312h257dd4b_5.conda
   hash:
-    md5: df8a9553466cd78553bd99e601e17693
-    sha256: 77292e2f47819cbdbfa30042fc75428abbddf9dc55d934bc72ecef496bc334da
+    md5: c5d9279e3e90a439cd7eac621d378d00
+    sha256: a11ddb252246e579bed502bff472c4ec7d18aa157adbd349fe9f3de0e4e53e15
   category: main
   optional: false
 - name: gdal
-  version: 3.8.3
+  version: 3.8.4
   manager: conda
   platform: osx-64
   dependencies:
     hdf5: '>=1.14.3,<1.14.4.0a0'
     libcxx: '>=16'
-    libgdal: 3.8.3
-    libxml2: '>=2.12.5,<3.0a0'
-    numpy: '>=1.26.3,<2.0a0'
+    libgdal: 3.8.4
+    libxml2: '>=2.12.6,<3.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     openssl: '>=3.2.1,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.8.3-py312h1be6df0_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.8.4-py312h1be6df0_5.conda
   hash:
-    md5: 914e0ca2e70cd05f778b91e409d5b6b3
-    sha256: c6204b80b1718b232d42bf81968c8ba19601387d11f7ca0a19cfec7ff23f97e1
+    md5: e77cb26e60bc7a2f2b9ad4c2d35f024e
+    sha256: 52dcdd46c5e50458271670666ca41cbf83be06218f72e8feeaf1c922c3423b66
   category: main
   optional: false
 - name: gdal
-  version: 3.8.3
+  version: 3.8.4
   manager: conda
   platform: osx-arm64
   dependencies:
     hdf5: '>=1.14.3,<1.14.4.0a0'
     libcxx: '>=16'
-    libgdal: 3.8.3
-    libxml2: '>=2.12.5,<3.0a0'
-    numpy: '>=1.26.3,<2.0a0'
+    libgdal: 3.8.4
+    libxml2: '>=2.12.6,<3.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     openssl: '>=3.2.1,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.8.3-py312h56161e1_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.8.4-py312h56161e1_5.conda
   hash:
-    md5: 4979fe3f323db513dce6e0eeb1e3d08b
-    sha256: b3c62b8a497fc39cb6b4f4039eef262d1bd76b00802fe7f66ff5f9b90bbc138c
+    md5: 63848d6de04fa1c2734bcbad65f32e79
+    sha256: 0774688419d356f93cfeebabe10406e3f3ccd658a628396f942877b2124d1e22
   category: main
   optional: false
 - name: gdal
-  version: 3.8.3
+  version: 3.8.4
   manager: conda
   platform: win-64
   dependencies:
     hdf5: '>=1.14.3,<1.14.4.0a0'
-    libgdal: 3.8.3
-    libxml2: '>=2.12.5,<3.0a0'
-    numpy: '>=1.26.3,<2.0a0'
+    libgdal: 3.8.4
+    libxml2: '>=2.12.6,<3.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     openssl: '>=3.2.1,<4.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/gdal-3.8.3-py312h36e25a9_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/gdal-3.8.4-py312h36e25a9_5.conda
   hash:
-    md5: 0292c4d1e3e1f091af18f1707c2a1044
-    sha256: 74912e7b112fbbc168407f945989d93f99af29dbd5a23aac94d0e61e8ee64419
+    md5: 45752ae67d53252996b53219071da344
+    sha256: 24e6d9f306add64ff976f2ca17c246b83387a6b787d25ee666d48de182bb27c5
   category: main
   optional: false
 - name: geopandas
@@ -3959,18 +3673,6 @@ package:
 - name: gettext
   version: 0.21.1
   manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/gettext-0.21.1-h27087fc_0.tar.bz2
-  hash:
-    md5: 14947d8770185e5153fdd04d4673ed37
-    sha256: 4fcfedc44e4c9a053f0416f9fc6ab6ed50644fca3a761126dbd00d09db1f546a
-  category: main
-  optional: false
-- name: gettext
-  version: 0.21.1
-  manager: conda
   platform: osx-64
   dependencies:
     libiconv: '>=1.17,<2.0a0'
@@ -3990,18 +3692,6 @@ package:
   hash:
     md5: 63d2ff6fddfa74e5458488fd311bf635
     sha256: 093b2f96dc4b48e4952ab8946facec98b34b708a056251fc19c23c3aad30039e
-  category: main
-  optional: false
-- name: gettext
-  version: 0.21.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    libiconv: '>=1.17,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/gettext-0.21.1-h5728263_0.tar.bz2
-  hash:
-    md5: 299d4fd6798a45337042ff5a48219e5f
-    sha256: 71c75b0a4dc2cf95d2860ea0076edf9f5558baeb4dacaeecb32643b199074616
   category: main
   optional: false
 - name: gflags
@@ -4076,151 +3766,44 @@ package:
   category: main
   optional: false
 - name: glog
-  version: 0.6.0
+  version: 0.7.0
   manager: conda
   platform: linux-64
   dependencies:
     gflags: '>=2.2.2,<2.3.0a0'
-    libgcc-ng: '>=10.3.0'
-    libstdcxx-ng: '>=10.3.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.6.0-h6f12383_0.tar.bz2
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.0-hed5481d_0.conda
   hash:
-    md5: b31f3565cb84435407594e548a2fb7b2
-    sha256: 888cbcfb67f6e3d88a4c4ab9d26c9a406f620c4101a35dc6d2dbadb95f2221d4
+    md5: a9ea19c48e11754899299f8123070f4e
+    sha256: 19f41db8f189ed9caec68ffb9ec97d5518b5ee6b58e0636d185f392f688a84a1
   category: main
   optional: false
 - name: glog
-  version: 0.6.0
+  version: 0.7.0
   manager: conda
   platform: osx-64
   dependencies:
+    __osx: '>=10.12'
     gflags: '>=2.2.2,<2.3.0a0'
-    libcxx: '>=12.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.6.0-h8ac2a54_0.tar.bz2
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.0-h31b1b29_0.conda
   hash:
-    md5: 69eb97ca709a136c53fdca1f2fd33ddf
-    sha256: fdb38560094fb4a952346dc72a79b3cb09e23e4d0cae9ba4f524e6e88203d3c8
+    md5: bda05f8f4c205124348c764dd82db33a
+    sha256: 49d39c6b0c38d9f2badfc37450ea45a40493669561d588ee81d9e5b7ed4478b7
   category: main
   optional: false
 - name: glog
-  version: 0.6.0
+  version: 0.7.0
   manager: conda
   platform: osx-arm64
   dependencies:
     gflags: '>=2.2.2,<2.3.0a0'
-    libcxx: '>=12.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.6.0-h6da1cb0_0.tar.bz2
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.0-hc6770e3_0.conda
   hash:
-    md5: 5a570729c7709399cf8511aeeda6f989
-    sha256: 4d772c42477f64be708594ac45870feba3e838977871118eb25e00deb0e9a73c
-  category: main
-  optional: false
-- name: h11
-  version: 0.14.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3'
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21ed0883505ba1910994f1df031a428
-    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
-  category: main
-  optional: false
-- name: h11
-  version: 0.14.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    typing_extensions: ''
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21ed0883505ba1910994f1df031a428
-    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
-  category: main
-  optional: false
-- name: h11
-  version: 0.14.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    typing_extensions: ''
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21ed0883505ba1910994f1df031a428
-    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
-  category: main
-  optional: false
-- name: h11
-  version: 0.14.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    typing_extensions: ''
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/h11-0.14.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b21ed0883505ba1910994f1df031a428
-    sha256: 817d2c77d53afe3f3d9cf7f6eb8745cdd8ea76c7adaa9d7ced75c455a2c2c085
-  category: main
-  optional: false
-- name: h2
-  version: 4.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    hpack: '>=4.0,<5'
-    hyperframe: '>=6.0,<7'
-    python: '>=3.6.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b748fbf7060927a6e82df7cb5ee8f097
-    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
-  category: main
-  optional: false
-- name: h2
-  version: 4.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6.1'
-    hpack: '>=4.0,<5'
-    hyperframe: '>=6.0,<7'
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b748fbf7060927a6e82df7cb5ee8f097
-    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
-  category: main
-  optional: false
-- name: h2
-  version: 4.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6.1'
-    hpack: '>=4.0,<5'
-    hyperframe: '>=6.0,<7'
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b748fbf7060927a6e82df7cb5ee8f097
-    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
-  category: main
-  optional: false
-- name: h2
-  version: 4.1.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6.1'
-    hpack: '>=4.0,<5'
-    hyperframe: '>=6.0,<7'
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: b748fbf7060927a6e82df7cb5ee8f097
-    sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
+    md5: 359f6720ba65b7a38b46a85d5ae13338
+    sha256: eba67027affe097ef11e4e9ffbb131a5b2ca3494d1b50e5cc1dd337813b1ab5c
   category: main
   optional: false
 - name: hdf4
@@ -4513,431 +4096,6 @@ package:
     sha256: 6ee8eb9080bb3268654e015dd17ad79d0c1ea98b2eee6b928ecd27f01d6b38e8
   category: main
   optional: false
-- name: ipykernel
-  version: 6.29.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __linux: ''
-    comm: '>=0.1.1'
-    debugpy: '>=1.6.5'
-    ipython: '>=7.23.1'
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    matplotlib-inline: '>=0.1'
-    nest-asyncio: ''
-    packaging: ''
-    psutil: ''
-    python: '>=3.8'
-    pyzmq: '>=24'
-    tornado: '>=6.1'
-    traitlets: '>=5.4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.2-pyhd33586a_0.conda
-  hash:
-    md5: c0e0eaceb52b50f1971295fe4546e8ed
-    sha256: 6cd66445c6a287623d02fe5fad0d67f8194ac582a7147ce092920fa20a8e3eec
-  category: main
-  optional: false
-- name: ipykernel
-  version: 6.29.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    packaging: ''
-    psutil: ''
-    nest-asyncio: ''
-    __osx: ''
-    appnope: ''
-    python: '>=3.8'
-    tornado: '>=6.1'
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
-    matplotlib-inline: '>=0.1'
-    debugpy: '>=1.6.5'
-    comm: '>=0.1.1'
-    traitlets: '>=5.4.0'
-    pyzmq: '>=24'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.2-pyh3cd1d5f_0.conda
-  hash:
-    md5: 70402d8d2b523e33c9b6090f5a9c74ff
-    sha256: bd454a69fe3dc80e4a11078aab370d87ee2bd863f386d619fb2bb051b4d6f82b
-  category: main
-  optional: false
-- name: ipykernel
-  version: 6.29.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    packaging: ''
-    psutil: ''
-    nest-asyncio: ''
-    __osx: ''
-    appnope: ''
-    python: '>=3.8'
-    tornado: '>=6.1'
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
-    matplotlib-inline: '>=0.1'
-    debugpy: '>=1.6.5'
-    comm: '>=0.1.1'
-    traitlets: '>=5.4.0'
-    pyzmq: '>=24'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.2-pyh3cd1d5f_0.conda
-  hash:
-    md5: 70402d8d2b523e33c9b6090f5a9c74ff
-    sha256: bd454a69fe3dc80e4a11078aab370d87ee2bd863f386d619fb2bb051b4d6f82b
-  category: main
-  optional: false
-- name: ipykernel
-  version: 6.29.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    packaging: ''
-    psutil: ''
-    nest-asyncio: ''
-    __win: ''
-    python: '>=3.8'
-    tornado: '>=6.1'
-    jupyter_client: '>=6.1.12'
-    jupyter_core: '>=4.12,!=5.0.*'
-    ipython: '>=7.23.1'
-    matplotlib-inline: '>=0.1'
-    debugpy: '>=1.6.5'
-    comm: '>=0.1.1'
-    traitlets: '>=5.4.0'
-    pyzmq: '>=24'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipykernel-6.29.2-pyha63f2e9_0.conda
-  hash:
-    md5: 65db5267b7fb095354b72735ddb4e08d
-    sha256: 735982c20a60d7b307b7de7a42cafd95ef37eb61e37db8abb627f2902ee9c32c
-  category: main
-  optional: false
-- name: ipython
-  version: 8.21.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-    decorator: ''
-    exceptiongroup: ''
-    jedi: '>=0.16'
-    matplotlib-inline: ''
-    pexpect: '>4.3'
-    pickleshare: ''
-    prompt-toolkit: '>=3.0.41,<3.1.0'
-    pygments: '>=2.4.0'
-    python: '>=3.10'
-    stack_data: ''
-    traitlets: '>=5'
-    typing_extensions: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.21.0-pyh707e725_0.conda
-  hash:
-    md5: 371344fdbdf9c70cfe9adb512a8cbca6
-    sha256: 521291dd15bf09fbb3ecea1c27536742d8e434c2e539b06776e734ee729bdead
-  category: main
-  optional: false
-- name: ipython
-  version: 8.21.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    typing_extensions: ''
-    __unix: ''
-    decorator: ''
-    exceptiongroup: ''
-    stack_data: ''
-    matplotlib-inline: ''
-    pickleshare: ''
-    python: '>=3.10'
-    pygments: '>=2.4.0'
-    traitlets: '>=5'
-    jedi: '>=0.16'
-    pexpect: '>4.3'
-    prompt-toolkit: '>=3.0.41,<3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.21.0-pyh707e725_0.conda
-  hash:
-    md5: 371344fdbdf9c70cfe9adb512a8cbca6
-    sha256: 521291dd15bf09fbb3ecea1c27536742d8e434c2e539b06776e734ee729bdead
-  category: main
-  optional: false
-- name: ipython
-  version: 8.21.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    typing_extensions: ''
-    __unix: ''
-    decorator: ''
-    exceptiongroup: ''
-    stack_data: ''
-    matplotlib-inline: ''
-    pickleshare: ''
-    python: '>=3.10'
-    pygments: '>=2.4.0'
-    traitlets: '>=5'
-    jedi: '>=0.16'
-    pexpect: '>4.3'
-    prompt-toolkit: '>=3.0.41,<3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.21.0-pyh707e725_0.conda
-  hash:
-    md5: 371344fdbdf9c70cfe9adb512a8cbca6
-    sha256: 521291dd15bf09fbb3ecea1c27536742d8e434c2e539b06776e734ee729bdead
-  category: main
-  optional: false
-- name: ipython
-  version: 8.21.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    typing_extensions: ''
-    colorama: ''
-    decorator: ''
-    __win: ''
-    exceptiongroup: ''
-    stack_data: ''
-    matplotlib-inline: ''
-    pickleshare: ''
-    python: '>=3.10'
-    pygments: '>=2.4.0'
-    traitlets: '>=5'
-    jedi: '>=0.16'
-    prompt-toolkit: '>=3.0.41,<3.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipython-8.21.0-pyh7428d3b_0.conda
-  hash:
-    md5: 632aeffb0cce428d8b91229dbe69dbce
-    sha256: 91d4fe1b927354287ec9ad0314232a58e988402a0e0d6322805f81c042737038
-  category: main
-  optional: false
-- name: ipywidgets
-  version: 8.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    comm: '>=0.1.3'
-    ipython: '>=6.1.0'
-    jupyterlab_widgets: '>=3.0.10,<3.1.0'
-    python: '>=3.7'
-    traitlets: '>=4.3.1'
-    widgetsnbextension: '>=4.0.10,<4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67f86478c78637f68c1f3858973021f2
-    sha256: 0be846f1374faa2d9b6f5e100187d56afa9268221f7c7815265f30aa008da8ca
-  category: main
-  optional: false
-- name: ipywidgets
-  version: 8.1.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-    traitlets: '>=4.3.1'
-    ipython: '>=6.1.0'
-    comm: '>=0.1.3'
-    jupyterlab_widgets: '>=3.0.10,<3.1.0'
-    widgetsnbextension: '>=4.0.10,<4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67f86478c78637f68c1f3858973021f2
-    sha256: 0be846f1374faa2d9b6f5e100187d56afa9268221f7c7815265f30aa008da8ca
-  category: main
-  optional: false
-- name: ipywidgets
-  version: 8.1.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    traitlets: '>=4.3.1'
-    ipython: '>=6.1.0'
-    comm: '>=0.1.3'
-    jupyterlab_widgets: '>=3.0.10,<3.1.0'
-    widgetsnbextension: '>=4.0.10,<4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67f86478c78637f68c1f3858973021f2
-    sha256: 0be846f1374faa2d9b6f5e100187d56afa9268221f7c7815265f30aa008da8ca
-  category: main
-  optional: false
-- name: ipywidgets
-  version: 8.1.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    traitlets: '>=4.3.1'
-    ipython: '>=6.1.0'
-    comm: '>=0.1.3'
-    jupyterlab_widgets: '>=3.0.10,<3.1.0'
-    widgetsnbextension: '>=4.0.10,<4.1.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/ipywidgets-8.1.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67f86478c78637f68c1f3858973021f2
-    sha256: 0be846f1374faa2d9b6f5e100187d56afa9268221f7c7815265f30aa008da8ca
-  category: main
-  optional: false
-- name: isoduration
-  version: 20.11.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    arrow: '>=0.15.0'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4cb68948e0b8429534380243d063a27a
-    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
-  category: main
-  optional: false
-- name: isoduration
-  version: 20.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-    arrow: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4cb68948e0b8429534380243d063a27a
-    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
-  category: main
-  optional: false
-- name: isoduration
-  version: 20.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    arrow: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4cb68948e0b8429534380243d063a27a
-    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
-  category: main
-  optional: false
-- name: isoduration
-  version: 20.11.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    arrow: '>=0.15.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/isoduration-20.11.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 4cb68948e0b8429534380243d063a27a
-    sha256: 7bb5c4d994361022f47a807b5e7d101b3dce16f7dd8a0af6ffad9f479d346493
-  category: main
-  optional: false
-- name: jasper
-  version: 4.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    freeglut: '>=3.2.2,<4.0a0'
-    libgcc-ng: '>=12'
-    libglu: '>=9.0.0,<10.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/jasper-4.2.0-he6dfbbe_0.conda
-  hash:
-    md5: ba48f3659627380d18e236312c65bd76
-    sha256: 2c7402313dfe18027b5a04968ed61da2f5fd4db412b30473bb634d3f0fd37b3e
-  category: main
-  optional: false
-- name: jasper
-  version: 4.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/jasper-4.2.0-h6ff19ee_0.conda
-  hash:
-    md5: a34e037a284f9029b962f9375e7b7770
-    sha256: 73403dee7eecc78d430ec371f4bbd8d8645b53ef10809c38b1835d971dbe2765
-  category: main
-  optional: false
-- name: jasper
-  version: 4.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jasper-4.2.0-h7c0e182_0.conda
-  hash:
-    md5: 100e3e14c13a78c72c50bba021f7e88c
-    sha256: 319b5f6a48f0574703a129e83f0e68a1e91826c203f6298e5004e64a6f7c98ef
-  category: main
-  optional: false
-- name: jasper
-  version: 4.2.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    freeglut: '>=3.2.2,<4.0a0'
-    libjpeg-turbo: '>=3.0.0,<4.0a0'
-    ucrt: '>=10.0.20348.0'
-    vc: '>=14.2,<15'
-    vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/jasper-4.2.0-h28f2b1a_0.conda
-  hash:
-    md5: e9241354826dbecd9d7f4ae95d7341e1
-    sha256: eb5d4f5375f7830f868482fdc7f2809941af5344c1184fb179a4954ccb34d0cc
-  category: main
-  optional: false
-- name: jedi
-  version: 0.19.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    parso: '>=0.8.3,<0.9.0'
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
-  category: main
-  optional: false
-- name: jedi
-  version: 0.19.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-    parso: '>=0.8.3,<0.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
-  category: main
-  optional: false
-- name: jedi
-  version: 0.19.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-    parso: '>=0.8.3,<0.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
-  category: main
-  optional: false
-- name: jedi
-  version: 0.19.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-    parso: '>=0.8.3,<0.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jedi-0.19.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 81a3be0b2023e1ea8555781f0ad904a2
-    sha256: 362f0936ef37dfd1eaa860190e42a6ebf8faa094eaa3be6aa4d9ace95f40047a
-  category: main
-  optional: false
 - name: jinja2
   version: 3.1.3
   manager: conda
@@ -5074,1195 +4232,6 @@ package:
   hash:
     md5: 7de5604deb99090c8e8c4863f60568d1
     sha256: d47138a2829ce47d2e9ec1dbe108d1a6fe58c5d8724ea904985a420ad760f93f
-  category: main
-  optional: false
-- name: json5
-  version: 0.9.14
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
-  hash:
-    md5: dac1dabba2b5a9d1aee175c5fcc7b436
-    sha256: 41514104208c092959bef0713cbd795e72c535f2f939b7903d8c97809f2adaa7
-  category: main
-  optional: false
-- name: json5
-  version: 0.9.14
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
-  hash:
-    md5: dac1dabba2b5a9d1aee175c5fcc7b436
-    sha256: 41514104208c092959bef0713cbd795e72c535f2f939b7903d8c97809f2adaa7
-  category: main
-  optional: false
-- name: json5
-  version: 0.9.14
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
-  hash:
-    md5: dac1dabba2b5a9d1aee175c5fcc7b436
-    sha256: 41514104208c092959bef0713cbd795e72c535f2f939b7903d8c97809f2adaa7
-  category: main
-  optional: false
-- name: json5
-  version: 0.9.14
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7,<4.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/json5-0.9.14-pyhd8ed1ab_0.conda
-  hash:
-    md5: dac1dabba2b5a9d1aee175c5fcc7b436
-    sha256: 41514104208c092959bef0713cbd795e72c535f2f939b7903d8c97809f2adaa7
-  category: main
-  optional: false
-- name: jsonpointer
-  version: '2.4'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/jsonpointer-2.4-py312h7900ff3_3.conda
-  hash:
-    md5: 50f62bdb9b60b13c2f6ae69957342e4d
-    sha256: c211a79cff8aa001a6e14e923c37278231dca7f0970d8db155c4b9e48ac87a5a
-  category: main
-  optional: false
-- name: jsonpointer
-  version: '2.4'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/jsonpointer-2.4-py312hb401068_3.conda
-  hash:
-    md5: 637aa8f6c1c61f659f1496e9b2dc7552
-    sha256: 883f6d635e58f49359f393e853e4e0043731fb0ce671283a2024db02a1ebc8f6
-  category: main
-  optional: false
-- name: jsonpointer
-  version: '2.4'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jsonpointer-2.4-py312h81bd7bf_3.conda
-  hash:
-    md5: 327361b24f5348cab04ad9b1f74e831d
-    sha256: 6cb2d17da9083e05f5ead7902a5cd6ec9567cd3da972c65c03f090515c9fa176
-  category: main
-  optional: false
-- name: jsonpointer
-  version: '2.4'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.12.0rc3,<3.13.0a0'
-    python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/win-64/jsonpointer-2.4-py312h2e8e312_3.conda
-  hash:
-    md5: 9d9572e257bf4559f20629efb0d3511d
-    sha256: 98d86d5ccb3a95da2cd96b394c157aa6fef0d4908b8878c3e2b5931f6bc5fd57
-  category: main
-  optional: false
-- name: jsonschema
-  version: 4.21.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    attrs: '>=22.2.0'
-    importlib_resources: '>=1.4.0'
-    jsonschema-specifications: '>=2023.03.6'
-    pkgutil-resolve-name: '>=1.3.10'
-    python: '>=3.8'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8a3a3d01629da20befa340919e3dd2c4
-    sha256: c5c1b4e08e91fdd697289015be1a176409b4e63942899a43b276f1f250be8129
-  category: main
-  optional: false
-- name: jsonschema
-  version: 4.21.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    attrs: '>=22.2.0'
-    importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
-    jsonschema-specifications: '>=2023.03.6'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8a3a3d01629da20befa340919e3dd2c4
-    sha256: c5c1b4e08e91fdd697289015be1a176409b4e63942899a43b276f1f250be8129
-  category: main
-  optional: false
-- name: jsonschema
-  version: 4.21.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    attrs: '>=22.2.0'
-    importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
-    jsonschema-specifications: '>=2023.03.6'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8a3a3d01629da20befa340919e3dd2c4
-    sha256: c5c1b4e08e91fdd697289015be1a176409b4e63942899a43b276f1f250be8129
-  category: main
-  optional: false
-- name: jsonschema
-  version: 4.21.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    attrs: '>=22.2.0'
-    importlib_resources: '>=1.4.0'
-    pkgutil-resolve-name: '>=1.3.10'
-    jsonschema-specifications: '>=2023.03.6'
-    referencing: '>=0.28.4'
-    rpds-py: '>=0.7.1'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.21.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 8a3a3d01629da20befa340919e3dd2c4
-    sha256: c5c1b4e08e91fdd697289015be1a176409b4e63942899a43b276f1f250be8129
-  category: main
-  optional: false
-- name: jsonschema-specifications
-  version: 2023.12.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib_resources: '>=1.4.0'
-    python: '>=3.8'
-    referencing: '>=0.31.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0e4efb5f35786a05af4809a2fb1f855
-    sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
-  category: main
-  optional: false
-- name: jsonschema-specifications
-  version: 2023.12.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    importlib_resources: '>=1.4.0'
-    referencing: '>=0.31.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0e4efb5f35786a05af4809a2fb1f855
-    sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
-  category: main
-  optional: false
-- name: jsonschema-specifications
-  version: 2023.12.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    importlib_resources: '>=1.4.0'
-    referencing: '>=0.31.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0e4efb5f35786a05af4809a2fb1f855
-    sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
-  category: main
-  optional: false
-- name: jsonschema-specifications
-  version: 2023.12.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    importlib_resources: '>=1.4.0'
-    referencing: '>=0.31.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0e4efb5f35786a05af4809a2fb1f855
-    sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
-  category: main
-  optional: false
-- name: jsonschema-with-format-nongpl
-  version: 4.21.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    fqdn: ''
-    idna: ''
-    isoduration: ''
-    jsonpointer: '>1.13'
-    jsonschema: '>=4.21.1,<4.21.2.0a0'
-    python: ''
-    rfc3339-validator: ''
-    rfc3986-validator: '>0.1.0'
-    uri-template: ''
-    webcolors: '>=1.11'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 26bce4b5405738c09304d4f4796b2c2a
-    sha256: 6e458c325c097956ac4605ef386f0d67bad5223041cedd66819892988b72f83a
-  category: main
-  optional: false
-- name: jsonschema-with-format-nongpl
-  version: 4.21.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: ''
-    idna: ''
-    rfc3339-validator: ''
-    uri-template: ''
-    fqdn: ''
-    isoduration: ''
-    jsonpointer: '>1.13'
-    webcolors: '>=1.11'
-    rfc3986-validator: '>0.1.0'
-    jsonschema: '>=4.21.1,<4.21.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 26bce4b5405738c09304d4f4796b2c2a
-    sha256: 6e458c325c097956ac4605ef386f0d67bad5223041cedd66819892988b72f83a
-  category: main
-  optional: false
-- name: jsonschema-with-format-nongpl
-  version: 4.21.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: ''
-    idna: ''
-    rfc3339-validator: ''
-    uri-template: ''
-    fqdn: ''
-    isoduration: ''
-    jsonpointer: '>1.13'
-    webcolors: '>=1.11'
-    rfc3986-validator: '>0.1.0'
-    jsonschema: '>=4.21.1,<4.21.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 26bce4b5405738c09304d4f4796b2c2a
-    sha256: 6e458c325c097956ac4605ef386f0d67bad5223041cedd66819892988b72f83a
-  category: main
-  optional: false
-- name: jsonschema-with-format-nongpl
-  version: 4.21.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: ''
-    idna: ''
-    rfc3339-validator: ''
-    uri-template: ''
-    fqdn: ''
-    isoduration: ''
-    jsonpointer: '>1.13'
-    webcolors: '>=1.11'
-    rfc3986-validator: '>0.1.0'
-    jsonschema: '>=4.21.1,<4.21.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-with-format-nongpl-4.21.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 26bce4b5405738c09304d4f4796b2c2a
-    sha256: 6e458c325c097956ac4605ef386f0d67bad5223041cedd66819892988b72f83a
-  category: main
-  optional: false
-- name: jupyter
-  version: 1.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ipykernel: ''
-    ipywidgets: ''
-    jupyter_console: ''
-    nbconvert: ''
-    notebook: ''
-    python: '>=3.6'
-    qtconsole-base: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.0.0-pyhd8ed1ab_10.conda
-  hash:
-    md5: 056b8cc3d9b03f54fc49e6d70d7dc359
-    sha256: 308b521b149e7a1739f717538b929bc2d87b9001b94f13ee8baa939632a86150
-  category: main
-  optional: false
-- name: jupyter
-  version: 1.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    ipywidgets: ''
-    notebook: ''
-    nbconvert: ''
-    ipykernel: ''
-    qtconsole-base: ''
-    jupyter_console: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.0.0-pyhd8ed1ab_10.conda
-  hash:
-    md5: 056b8cc3d9b03f54fc49e6d70d7dc359
-    sha256: 308b521b149e7a1739f717538b929bc2d87b9001b94f13ee8baa939632a86150
-  category: main
-  optional: false
-- name: jupyter
-  version: 1.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    ipywidgets: ''
-    notebook: ''
-    nbconvert: ''
-    ipykernel: ''
-    qtconsole-base: ''
-    jupyter_console: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.0.0-pyhd8ed1ab_10.conda
-  hash:
-    md5: 056b8cc3d9b03f54fc49e6d70d7dc359
-    sha256: 308b521b149e7a1739f717538b929bc2d87b9001b94f13ee8baa939632a86150
-  category: main
-  optional: false
-- name: jupyter
-  version: 1.0.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    ipywidgets: ''
-    notebook: ''
-    nbconvert: ''
-    ipykernel: ''
-    qtconsole-base: ''
-    jupyter_console: ''
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-1.0.0-pyhd8ed1ab_10.conda
-  hash:
-    md5: 056b8cc3d9b03f54fc49e6d70d7dc359
-    sha256: 308b521b149e7a1739f717538b929bc2d87b9001b94f13ee8baa939632a86150
-  category: main
-  optional: false
-- name: jupyter-lsp
-  version: 2.2.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.1.2'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: ed56b103cac2db68f22909e9f5cca6b6
-    sha256: d8ab253be3df67be1b31fe040a8386e071ff065ef4442b94a722a45fa3562fbe
-  category: main
-  optional: false
-- name: jupyter-lsp
-  version: 2.2.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.1.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: ed56b103cac2db68f22909e9f5cca6b6
-    sha256: d8ab253be3df67be1b31fe040a8386e071ff065ef4442b94a722a45fa3562fbe
-  category: main
-  optional: false
-- name: jupyter-lsp
-  version: 2.2.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.1.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: ed56b103cac2db68f22909e9f5cca6b6
-    sha256: d8ab253be3df67be1b31fe040a8386e071ff065ef4442b94a722a45fa3562fbe
-  category: main
-  optional: false
-- name: jupyter-lsp
-  version: 2.2.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.1.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter-lsp-2.2.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: ed56b103cac2db68f22909e9f5cca6b6
-    sha256: d8ab253be3df67be1b31fe040a8386e071ff065ef4442b94a722a45fa3562fbe
-  category: main
-  optional: false
-- name: jupyter_client
-  version: 8.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    importlib_metadata: '>=4.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    python: '>=3.8'
-    python-dateutil: '>=2.8.2'
-    pyzmq: '>=23.0'
-    tornado: '>=6.2'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6bd3f1069cdebb44c7ae9efb900e312d
-    sha256: 86cbb9070862cf23a245451efce539ca214e610849d0950bb8ac90c545bd158d
-  category: main
-  optional: false
-- name: jupyter_client
-  version: 8.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    python-dateutil: '>=2.8.2'
-    jupyter_core: '>=4.12,!=5.0.*'
-    importlib_metadata: '>=4.8.3'
-    traitlets: '>=5.3'
-    pyzmq: '>=23.0'
-    tornado: '>=6.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6bd3f1069cdebb44c7ae9efb900e312d
-    sha256: 86cbb9070862cf23a245451efce539ca214e610849d0950bb8ac90c545bd158d
-  category: main
-  optional: false
-- name: jupyter_client
-  version: 8.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    python-dateutil: '>=2.8.2'
-    jupyter_core: '>=4.12,!=5.0.*'
-    importlib_metadata: '>=4.8.3'
-    traitlets: '>=5.3'
-    pyzmq: '>=23.0'
-    tornado: '>=6.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6bd3f1069cdebb44c7ae9efb900e312d
-    sha256: 86cbb9070862cf23a245451efce539ca214e610849d0950bb8ac90c545bd158d
-  category: main
-  optional: false
-- name: jupyter_client
-  version: 8.6.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    python-dateutil: '>=2.8.2'
-    jupyter_core: '>=4.12,!=5.0.*'
-    importlib_metadata: '>=4.8.3'
-    traitlets: '>=5.3'
-    pyzmq: '>=23.0'
-    tornado: '>=6.2'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_client-8.6.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 6bd3f1069cdebb44c7ae9efb900e312d
-    sha256: 86cbb9070862cf23a245451efce539ca214e610849d0950bb8ac90c545bd158d
-  category: main
-  optional: false
-- name: jupyter_console
-  version: 6.6.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ipykernel: '>=6.14'
-    ipython: ''
-    jupyter_client: '>=7.0.0'
-    jupyter_core: '>=4.12,!=5.0.*'
-    prompt_toolkit: '>=3.0.30'
-    pygments: ''
-    python: '>=3.7'
-    pyzmq: '>=17'
-    traitlets: '>=5.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7cf6f52a66f8e3cd9d8b6c231262dcab
-    sha256: 4e51764d5fe2f6e43d83bcfbcf8b4da6569721bf82eaf4d647be8717cd6be75a
-  category: main
-  optional: false
-- name: jupyter_console
-  version: 6.6.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    ipython: ''
-    pygments: ''
-    python: '>=3.7'
-    pyzmq: '>=17'
-    jupyter_core: '>=4.12,!=5.0.*'
-    jupyter_client: '>=7.0.0'
-    ipykernel: '>=6.14'
-    traitlets: '>=5.4'
-    prompt_toolkit: '>=3.0.30'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7cf6f52a66f8e3cd9d8b6c231262dcab
-    sha256: 4e51764d5fe2f6e43d83bcfbcf8b4da6569721bf82eaf4d647be8717cd6be75a
-  category: main
-  optional: false
-- name: jupyter_console
-  version: 6.6.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    ipython: ''
-    pygments: ''
-    python: '>=3.7'
-    pyzmq: '>=17'
-    jupyter_core: '>=4.12,!=5.0.*'
-    jupyter_client: '>=7.0.0'
-    ipykernel: '>=6.14'
-    traitlets: '>=5.4'
-    prompt_toolkit: '>=3.0.30'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7cf6f52a66f8e3cd9d8b6c231262dcab
-    sha256: 4e51764d5fe2f6e43d83bcfbcf8b4da6569721bf82eaf4d647be8717cd6be75a
-  category: main
-  optional: false
-- name: jupyter_console
-  version: 6.6.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    ipython: ''
-    pygments: ''
-    python: '>=3.7'
-    pyzmq: '>=17'
-    jupyter_core: '>=4.12,!=5.0.*'
-    jupyter_client: '>=7.0.0'
-    ipykernel: '>=6.14'
-    traitlets: '>=5.4'
-    prompt_toolkit: '>=3.0.30'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_console-6.6.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 7cf6f52a66f8e3cd9d8b6c231262dcab
-    sha256: 4e51764d5fe2f6e43d83bcfbcf8b4da6569721bf82eaf4d647be8717cd6be75a
-  category: main
-  optional: false
-- name: jupyter_core
-  version: 5.7.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    platformdirs: '>=2.5'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/linux-64/jupyter_core-5.7.1-py312h7900ff3_0.conda
-  hash:
-    md5: a26a2c80b748744dafb642a9a729e119
-    sha256: ce667e4829f934ace4437474ad4775bbd5ac53a597529afebfd8533dec1e697c
-  category: main
-  optional: false
-- name: jupyter_core
-  version: 5.7.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    platformdirs: '>=2.5'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/osx-64/jupyter_core-5.7.1-py312hb401068_0.conda
-  hash:
-    md5: 5db7505ee6fbb00f060782a8d93f974a
-    sha256: 410f57e7812dbf9122d416b4a9fc8d3833836fe40929ef845e221d4c8de0edbc
-  category: main
-  optional: false
-- name: jupyter_core
-  version: 5.7.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    platformdirs: '>=2.5'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jupyter_core-5.7.1-py312h81bd7bf_0.conda
-  hash:
-    md5: 64dc06b5c9b1ff20ad9afcf00f588cfc
-    sha256: 56e3b3527364b8065a178112c146f07a59106eefe0a73f6cfaac38ea0f93eec8
-  category: main
-  optional: false
-- name: jupyter_core
-  version: 5.7.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    platformdirs: '>=2.5'
-    python: '>=3.12,<3.13.0a0'
-    python_abi: 3.12.*
-    pywin32: '>=300'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/win-64/jupyter_core-5.7.1-py312h2e8e312_0.conda
-  hash:
-    md5: 4169f425045de1e7e7ddc19fba8eaf71
-    sha256: d4ad01e013ad873c08fb8118c339695d9f289a908d59a9ffc1e68833ad61405b
-  category: main
-  optional: false
-- name: jupyter_events
-  version: 0.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    jsonschema-with-format-nongpl: '>=4.18.0'
-    python: '>=3.8'
-    python-json-logger: '>=2.0.4'
-    pyyaml: '>=5.3'
-    referencing: ''
-    rfc3339-validator: ''
-    rfc3986-validator: '>=0.1.1'
-    traitlets: '>=5.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 00ba25993f0dba38cf72a7224e33289f
-    sha256: 713f0cc927a862862a6d35bfb29c4114f987e4f59e2a8a14f71f23fcd7edfec3
-  category: main
-  optional: false
-- name: jupyter_events
-  version: 0.9.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    rfc3339-validator: ''
-    referencing: ''
-    python: '>=3.8'
-    pyyaml: '>=5.3'
-    rfc3986-validator: '>=0.1.1'
-    traitlets: '>=5.3'
-    python-json-logger: '>=2.0.4'
-    jsonschema-with-format-nongpl: '>=4.18.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 00ba25993f0dba38cf72a7224e33289f
-    sha256: 713f0cc927a862862a6d35bfb29c4114f987e4f59e2a8a14f71f23fcd7edfec3
-  category: main
-  optional: false
-- name: jupyter_events
-  version: 0.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    rfc3339-validator: ''
-    referencing: ''
-    python: '>=3.8'
-    pyyaml: '>=5.3'
-    rfc3986-validator: '>=0.1.1'
-    traitlets: '>=5.3'
-    python-json-logger: '>=2.0.4'
-    jsonschema-with-format-nongpl: '>=4.18.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 00ba25993f0dba38cf72a7224e33289f
-    sha256: 713f0cc927a862862a6d35bfb29c4114f987e4f59e2a8a14f71f23fcd7edfec3
-  category: main
-  optional: false
-- name: jupyter_events
-  version: 0.9.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    rfc3339-validator: ''
-    referencing: ''
-    python: '>=3.8'
-    pyyaml: '>=5.3'
-    rfc3986-validator: '>=0.1.1'
-    traitlets: '>=5.3'
-    python-json-logger: '>=2.0.4'
-    jsonschema-with-format-nongpl: '>=4.18.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_events-0.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 00ba25993f0dba38cf72a7224e33289f
-    sha256: 713f0cc927a862862a6d35bfb29c4114f987e4f59e2a8a14f71f23fcd7edfec3
-  category: main
-  optional: false
-- name: jupyter_server
-  version: 2.12.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    anyio: '>=3.1.0'
-    argon2-cffi: ''
-    jinja2: ''
-    jupyter_client: '>=7.4.4'
-    jupyter_core: '>=4.12,!=5.0.*'
-    jupyter_events: '>=0.9.0'
-    jupyter_server_terminals: ''
-    nbconvert-core: '>=6.4.4'
-    nbformat: '>=5.3.0'
-    overrides: ''
-    packaging: ''
-    prometheus_client: ''
-    python: '>=3.8'
-    pyzmq: '>=24'
-    send2trash: '>=1.8.2'
-    terminado: '>=0.8.3'
-    tornado: '>=6.2.0'
-    traitlets: '>=5.6.0'
-    websocket-client: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.12.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 755177a956fa6dd90d5cfcbbb5084de2
-    sha256: 43dcd238c656c7ecf3228be8735def530cad5181f990c042ba202b9e383d2b1f
-  category: main
-  optional: false
-- name: jupyter_server
-  version: 2.12.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    packaging: ''
-    jinja2: ''
-    prometheus_client: ''
-    websocket-client: ''
-    argon2-cffi: ''
-    overrides: ''
-    jupyter_server_terminals: ''
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    tornado: '>=6.2.0'
-    nbconvert-core: '>=6.4.4'
-    pyzmq: '>=24'
-    jupyter_client: '>=7.4.4'
-    nbformat: '>=5.3.0'
-    traitlets: '>=5.6.0'
-    anyio: '>=3.1.0'
-    send2trash: '>=1.8.2'
-    jupyter_events: '>=0.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.12.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 755177a956fa6dd90d5cfcbbb5084de2
-    sha256: 43dcd238c656c7ecf3228be8735def530cad5181f990c042ba202b9e383d2b1f
-  category: main
-  optional: false
-- name: jupyter_server
-  version: 2.12.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    packaging: ''
-    jinja2: ''
-    prometheus_client: ''
-    websocket-client: ''
-    argon2-cffi: ''
-    overrides: ''
-    jupyter_server_terminals: ''
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    tornado: '>=6.2.0'
-    nbconvert-core: '>=6.4.4'
-    pyzmq: '>=24'
-    jupyter_client: '>=7.4.4'
-    nbformat: '>=5.3.0'
-    traitlets: '>=5.6.0'
-    anyio: '>=3.1.0'
-    send2trash: '>=1.8.2'
-    jupyter_events: '>=0.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.12.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 755177a956fa6dd90d5cfcbbb5084de2
-    sha256: 43dcd238c656c7ecf3228be8735def530cad5181f990c042ba202b9e383d2b1f
-  category: main
-  optional: false
-- name: jupyter_server
-  version: 2.12.5
-  manager: conda
-  platform: win-64
-  dependencies:
-    packaging: ''
-    jinja2: ''
-    prometheus_client: ''
-    websocket-client: ''
-    argon2-cffi: ''
-    overrides: ''
-    jupyter_server_terminals: ''
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-    jupyter_core: '>=4.12,!=5.0.*'
-    tornado: '>=6.2.0'
-    nbconvert-core: '>=6.4.4'
-    pyzmq: '>=24'
-    jupyter_client: '>=7.4.4'
-    nbformat: '>=5.3.0'
-    traitlets: '>=5.6.0'
-    anyio: '>=3.1.0'
-    send2trash: '>=1.8.2'
-    jupyter_events: '>=0.9.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server-2.12.5-pyhd8ed1ab_0.conda
-  hash:
-    md5: 755177a956fa6dd90d5cfcbbb5084de2
-    sha256: 43dcd238c656c7ecf3228be8735def530cad5181f990c042ba202b9e383d2b1f
-  category: main
-  optional: false
-- name: jupyter_server_terminals
-  version: 0.5.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0152d13c9deb13639fc84df884d50b6
-    sha256: a625150744fdffb646fb4451edc68b3eff56eeace4e86b83dc4a860479c9857c
-  category: main
-  optional: false
-- name: jupyter_server_terminals
-  version: 0.5.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0152d13c9deb13639fc84df884d50b6
-    sha256: a625150744fdffb646fb4451edc68b3eff56eeace4e86b83dc4a860479c9857c
-  category: main
-  optional: false
-- name: jupyter_server_terminals
-  version: 0.5.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0152d13c9deb13639fc84df884d50b6
-    sha256: a625150744fdffb646fb4451edc68b3eff56eeace4e86b83dc4a860479c9857c
-  category: main
-  optional: false
-- name: jupyter_server_terminals
-  version: 0.5.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    terminado: '>=0.8.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyter_server_terminals-0.5.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: a0152d13c9deb13639fc84df884d50b6
-    sha256: a625150744fdffb646fb4451edc68b3eff56eeace4e86b83dc4a860479c9857c
-  category: main
-  optional: false
-- name: jupyterlab
-  version: 4.1.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    async-lru: '>=1.0.0'
-    httpx: '>=0.25.0'
-    importlib_metadata: '>=4.8.3'
-    importlib_resources: '>=1.4'
-    ipykernel: ''
-    jinja2: '>=3.0.3'
-    jupyter-lsp: '>=2.0.0'
-    jupyter_core: ''
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab_server: '>=2.19.0,<3'
-    notebook-shim: '>=0.2'
-    packaging: ''
-    python: '>=3.8'
-    tomli: ''
-    tornado: '>=6.2.0'
-    traitlets: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: b4a530065ad9654d5100373a4aecf0c4
-    sha256: 397f3ba090f5109b4e4a844f4c52327cc7c1fe042b1a2fcb4eb858efbe39aca7
-  category: main
-  optional: false
-- name: jupyterlab
-  version: 4.1.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    packaging: ''
-    traitlets: ''
-    tomli: ''
-    ipykernel: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    jinja2: '>=3.0.3'
-    importlib_metadata: '>=4.8.3'
-    jupyter_server: '>=2.4.0,<3'
-    importlib_resources: '>=1.4'
-    jupyter-lsp: '>=2.0.0'
-    async-lru: '>=1.0.0'
-    jupyterlab_server: '>=2.19.0,<3'
-    notebook-shim: '>=0.2'
-    httpx: '>=0.25.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: b4a530065ad9654d5100373a4aecf0c4
-    sha256: 397f3ba090f5109b4e4a844f4c52327cc7c1fe042b1a2fcb4eb858efbe39aca7
-  category: main
-  optional: false
-- name: jupyterlab
-  version: 4.1.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    packaging: ''
-    traitlets: ''
-    tomli: ''
-    ipykernel: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    jinja2: '>=3.0.3'
-    importlib_metadata: '>=4.8.3'
-    jupyter_server: '>=2.4.0,<3'
-    importlib_resources: '>=1.4'
-    jupyter-lsp: '>=2.0.0'
-    async-lru: '>=1.0.0'
-    jupyterlab_server: '>=2.19.0,<3'
-    notebook-shim: '>=0.2'
-    httpx: '>=0.25.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: b4a530065ad9654d5100373a4aecf0c4
-    sha256: 397f3ba090f5109b4e4a844f4c52327cc7c1fe042b1a2fcb4eb858efbe39aca7
-  category: main
-  optional: false
-- name: jupyterlab
-  version: 4.1.1
-  manager: conda
-  platform: win-64
-  dependencies:
-    packaging: ''
-    traitlets: ''
-    tomli: ''
-    ipykernel: ''
-    jupyter_core: ''
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    jinja2: '>=3.0.3'
-    importlib_metadata: '>=4.8.3'
-    jupyter_server: '>=2.4.0,<3'
-    importlib_resources: '>=1.4'
-    jupyter-lsp: '>=2.0.0'
-    async-lru: '>=1.0.0'
-    jupyterlab_server: '>=2.19.0,<3'
-    notebook-shim: '>=0.2'
-    httpx: '>=0.25.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.1.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: b4a530065ad9654d5100373a4aecf0c4
-    sha256: 397f3ba090f5109b4e4a844f4c52327cc7c1fe042b1a2fcb4eb858efbe39aca7
-  category: main
-  optional: false
-- name: jupyterlab_pygments
-  version: 0.3.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    pygments: '>=2.4.1,<3'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: afcd1b53bcac8844540358e33f33d28f
-    sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
-  category: main
-  optional: false
-- name: jupyterlab_pygments
-  version: 0.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-    pygments: '>=2.4.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: afcd1b53bcac8844540358e33f33d28f
-    sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
-  category: main
-  optional: false
-- name: jupyterlab_pygments
-  version: 0.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    pygments: '>=2.4.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: afcd1b53bcac8844540358e33f33d28f
-    sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
-  category: main
-  optional: false
-- name: jupyterlab_pygments
-  version: 0.3.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    pygments: '>=2.4.1,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_pygments-0.3.0-pyhd8ed1ab_1.conda
-  hash:
-    md5: afcd1b53bcac8844540358e33f33d28f
-    sha256: 4aa622bbcf97e44cd1adf0100b7ff71b7e20268f043bdf6feae4d16152f1f242
-  category: main
-  optional: false
-- name: jupyterlab_server
-  version: 2.25.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    babel: '>=2.10'
-    importlib-metadata: '>=4.8.3'
-    jinja2: '>=3.0.3'
-    json5: '>=0.9.0'
-    jsonschema: '>=4.18'
-    jupyter_server: '>=1.21,<3'
-    packaging: '>=21.3'
-    python: '>=3.8'
-    requests: '>=2.31'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: f45557d5551b54dc2a74133a310bc1ba
-    sha256: 51c13a87072a64df1a0ae14fbb470bc4e36becf4d50693ffab53174199ca4f4b
-  category: main
-  optional: false
-- name: jupyterlab_server
-  version: 2.25.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    packaging: '>=21.3'
-    jinja2: '>=3.0.3'
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.21,<3'
-    babel: '>=2.10'
-    json5: '>=0.9.0'
-    requests: '>=2.31'
-    jsonschema: '>=4.18'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: f45557d5551b54dc2a74133a310bc1ba
-    sha256: 51c13a87072a64df1a0ae14fbb470bc4e36becf4d50693ffab53174199ca4f4b
-  category: main
-  optional: false
-- name: jupyterlab_server
-  version: 2.25.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    packaging: '>=21.3'
-    jinja2: '>=3.0.3'
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.21,<3'
-    babel: '>=2.10'
-    json5: '>=0.9.0'
-    requests: '>=2.31'
-    jsonschema: '>=4.18'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: f45557d5551b54dc2a74133a310bc1ba
-    sha256: 51c13a87072a64df1a0ae14fbb470bc4e36becf4d50693ffab53174199ca4f4b
-  category: main
-  optional: false
-- name: jupyterlab_server
-  version: 2.25.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    packaging: '>=21.3'
-    jinja2: '>=3.0.3'
-    importlib-metadata: '>=4.8.3'
-    jupyter_server: '>=1.21,<3'
-    babel: '>=2.10'
-    json5: '>=0.9.0'
-    requests: '>=2.31'
-    jsonschema: '>=4.18'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.25.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: f45557d5551b54dc2a74133a310bc1ba
-    sha256: 51c13a87072a64df1a0ae14fbb470bc4e36becf4d50693ffab53174199ca4f4b
-  category: main
-  optional: false
-- name: jupyterlab_widgets
-  version: 3.0.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.10-pyhd8ed1ab_0.conda
-  hash:
-    md5: 16b73b2c4ff7dda8bbecf88aadfe2027
-    sha256: 7c14d0b377ddd2e21f23d2f55fbd827aca726860e504a131b67ef936aef2b8c4
-  category: main
-  optional: false
-- name: jupyterlab_widgets
-  version: 3.0.10
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.10-pyhd8ed1ab_0.conda
-  hash:
-    md5: 16b73b2c4ff7dda8bbecf88aadfe2027
-    sha256: 7c14d0b377ddd2e21f23d2f55fbd827aca726860e504a131b67ef936aef2b8c4
-  category: main
-  optional: false
-- name: jupyterlab_widgets
-  version: 3.0.10
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.10-pyhd8ed1ab_0.conda
-  hash:
-    md5: 16b73b2c4ff7dda8bbecf88aadfe2027
-    sha256: 7c14d0b377ddd2e21f23d2f55fbd827aca726860e504a131b67ef936aef2b8c4
-  category: main
-  optional: false
-- name: jupyterlab_widgets
-  version: 3.0.10
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_widgets-3.0.10-pyhd8ed1ab_0.conda
-  hash:
-    md5: 16b73b2c4ff7dda8bbecf88aadfe2027
-    sha256: 7c14d0b377ddd2e21f23d2f55fbd827aca726860e504a131b67ef936aef2b8c4
   category: main
   optional: false
 - name: kealib
@@ -6568,105 +4537,105 @@ package:
   category: main
   optional: false
 - name: libabseil
-  version: '20230802.1'
+  version: '20240116.1'
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20230802.1-cxx17_h59595ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20240116.1-cxx17_h59595ed_2.conda
   hash:
-    md5: 2785ddf4cb0e7e743477991d64353947
-    sha256: 8729021a93e67bb93b4e73ef0a132499db516accfea11561b667635bcd0507e7
+    md5: 75648bc5dd3b8eab22406876c24d81ec
+    sha256: 9951421311285dd4335ad3aceffb223a4d3bc90fb804245508cd27aceb184a29
   category: main
   optional: false
 - name: libabseil
-  version: '20230802.1'
+  version: '20240116.1'
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20230802.1-cxx17_h048a20a_0.conda
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20240116.1-cxx17_hc1bcbd7_2.conda
   hash:
-    md5: 6554f5fb47c025273268bcdb7bf3cd48
-    sha256: 05431a6adb376a865e10d4ae673399d7890083c06f61cf18edb7c6629e75f39e
+    md5: 819934a15bc13a0d30778bf18446ada6
+    sha256: 30c0f569949a2fa0c5fd9aae3416e3f6623b9dd6fccdaa8d3437f143b67cca2a
   category: main
   optional: false
 - name: libabseil
-  version: '20230802.1'
+  version: '20240116.1'
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20230802.1-cxx17_h13dd4ca_0.conda
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20240116.1-cxx17_hebf3989_2.conda
   hash:
-    md5: fb6dfadc1898666616dfda242d8aea10
-    sha256: 459a58f36607246b4483d7a370c2d9a03e7f824e79da2c6e3e9d62abf80393e7
+    md5: 0b85aac2fab429166f76940791de071a
+    sha256: 3e87e8da8e40c71f6107386f6e87aeadc8c7b42e2736f6ac894abe50c763d642
   category: main
   optional: false
 - name: libabseil
-  version: '20230802.1'
+  version: '20240116.1'
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20230802.1-cxx17_h63175ca_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libabseil-20240116.1-cxx17_h63175ca_2.conda
   hash:
-    md5: 02674c18394394ee4f76cdbd1012f526
-    sha256: 8a016d49fad3d4216ce5ae4a60869b5384d31b2009e1ed9f445b6551ce7ef9e8
+    md5: bda6bc65300c4188933d8c68abc97923
+    sha256: 565071112e6339051b037bb9c5dae3f4bbc3b45c6f7b8ee598d0ec9056346c93
   category: main
   optional: false
 - name: libaec
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.2-h59595ed_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libaec-1.1.3-h59595ed_0.conda
   hash:
-    md5: 127b0be54c1c90760d7fe02ea7a56426
-    sha256: fdde15e74dc099ab1083823ec0f615958e53d9a8fae10405af977de251668bea
+    md5: 5e97e271911b8b2001a8b71860c32faa
+    sha256: 2ef420a655528bca9d269086cf33b7e90d2f54ad941b437fb1ed5eca87cee017
   category: main
   optional: false
 - name: libaec
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.2-he965462_1.conda
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libaec-1.1.3-h73e2aa4_0.conda
   hash:
-    md5: faa179050abc6af1385e0fe9dd074f91
-    sha256: 1b0a0b9b67e8f155ebdc7205a7421c7aff4850a740fc9f88b3fa23282c98ed72
+    md5: 66d3c1f6dd4636216b4fca7a748d50eb
+    sha256: dae5921339c5d89f4bf58a95fd4e9c76270dbf7f6a94f3c5081b574905fcccf8
   category: main
   optional: false
 - name: libaec
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.2-h13dd4ca_1.conda
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libaec-1.1.3-hebf3989_0.conda
   hash:
-    md5: b7962cdc2cedcc9f8d12928824c11fbd
-    sha256: c9d6f01d511bd3686ce590addf829f34031b95e3feb34418496cbb45924c5d17
+    md5: 6f0b8e56d2e7bae12a18fc5b2cd9f310
+    sha256: 896189b7b48a194c46a3556ea04943ef81cbe0498521231f8eb25816a68bc8ed
   category: main
   optional: false
 - name: libaec
-  version: 1.1.2
+  version: 1.1.3
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.2-h63175ca_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libaec-1.1.3-h63175ca_0.conda
   hash:
-    md5: 0b252d2bf460364bccb1523bcdbe4af6
-    sha256: 731dc77bce7d6425e2113b902023fba146e827cfe301bac565f92cc4e749588a
+    md5: 8723000f6ffdbdaef16025f0a01b64c5
+    sha256: f5c293d3cfc00f71dfdb64bd65ab53625565f8778fc2d5790575bef238976ebf
   category: main
   optional: false
 - name: libarchive
@@ -6752,436 +4721,445 @@ package:
   category: main
   optional: false
 - name: libarrow
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    aws-crt-cpp: '>=0.26.1,<0.26.2.0a0'
-    aws-sdk-cpp: '>=1.11.242,<1.11.243.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    aws-sdk-cpp: '>=1.11.267,<1.11.268.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.6.0,<0.7.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
+    glog: '>=0.7.0,<0.8.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
     libgcc-ng: '>=12'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    libgoogle-cloud: '>=2.22.0,<2.23.0a0'
+    libgoogle-cloud-storage: '>=2.22.0,<2.23.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libstdcxx-ng: '>=12'
     libutf8proc: '>=2.8.0,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=1.9.2,<1.9.3.0a0'
+    orc: '>=2.0.0,<2.0.1.0a0'
     re2: ''
     snappy: '>=1.1.10,<2.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-15.0.0-he2c5238_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-15.0.2-hb86450c_1_cpu.conda
   hash:
-    md5: cd7cd1c21dc42befdbb44b5afe2cd048
-    sha256: d802220e0157586c7ea382472945b040b54db98f0a3fb6d14f89b663e77cfe8b
+    md5: b68f648f3e2f60755adaa5bfb93287d0
+    sha256: f99e523a0dea433fcc79caf18057ef83621fd28da6f1b3e42096c4deaa485416
   category: main
   optional: false
 - name: libarrow
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    aws-crt-cpp: '>=0.26.1,<0.26.2.0a0'
-    aws-sdk-cpp: '>=1.11.242,<1.11.243.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    aws-sdk-cpp: '>=1.11.267,<1.11.268.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.6.0,<0.7.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
+    glog: '>=0.7.0,<0.8.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libcxx: '>=14'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    libcxx: '>=16'
+    libgoogle-cloud: '>=2.22.0,<2.23.0a0'
+    libgoogle-cloud-storage: '>=2.22.0,<2.23.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libutf8proc: '>=2.8.0,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=1.9.2,<1.9.3.0a0'
+    orc: '>=2.0.0,<2.0.1.0a0'
     re2: ''
     snappy: '>=1.1.10,<2.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-15.0.0-h9a9dd9d_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-15.0.2-h8d4fe2c_1_cpu.conda
   hash:
-    md5: 2debacaff79a2ea6c8f65a6ab720ff40
-    sha256: 5bef0cbb8bf8e1297a4cf339ff30b743be5a9545968fbff8d35be302a852b628
+    md5: 0dfd8ebfe7557c521e195b40375735e7
+    sha256: 0c00897262e54c54f3769384518792f4dda43e384111cfedb2fc6c85ad8e1fb9
   category: main
   optional: false
 - name: libarrow
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    aws-crt-cpp: '>=0.26.1,<0.26.2.0a0'
-    aws-sdk-cpp: '>=1.11.242,<1.11.243.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    aws-sdk-cpp: '>=1.11.267,<1.11.268.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    glog: '>=0.6.0,<0.7.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
+    glog: '>=0.7.0,<0.8.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
-    libcxx: '>=14'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    libcxx: '>=16'
+    libgoogle-cloud: '>=2.22.0,<2.23.0a0'
+    libgoogle-cloud-storage: '>=2.22.0,<2.23.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libutf8proc: '>=2.8.0,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    orc: '>=1.9.2,<1.9.3.0a0'
+    orc: '>=2.0.0,<2.0.1.0a0'
     re2: ''
     snappy: '>=1.1.10,<2.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-15.0.0-h906e67b_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-15.0.2-h5e64418_1_cpu.conda
   hash:
-    md5: 6dc657103564e2cdb4f0f06f8c183685
-    sha256: ade3ac9c040bee2cf74cbd84a5e0db55b1fda3c4058f483fad47358f89560beb
+    md5: d0ab2045139252a296c00c72d350f1db
+    sha256: 79767d66d9abc903fe68c8b00f24a697a3c45fc53a6245d04ffdb4df18c81b00
   category: main
   optional: false
 - name: libarrow
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: win-64
   dependencies:
-    aws-crt-cpp: '>=0.26.1,<0.26.2.0a0'
-    aws-sdk-cpp: '>=1.11.242,<1.11.243.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    aws-sdk-cpp: '>=1.11.267,<1.11.268.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libbrotlidec: '>=1.1.0,<1.2.0a0'
     libbrotlienc: '>=1.1.0,<1.2.0a0'
     libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
+    libgoogle-cloud: '>=2.22.0,<2.23.0a0'
+    libgoogle-cloud-storage: '>=2.22.0,<2.23.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libutf8proc: '>=2.8.0,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     openssl: '>=3.2.1,<4.0a0'
-    orc: '>=1.9.2,<1.9.3.0a0'
+    orc: '>=2.0.0,<2.0.1.0a0'
     re2: ''
     snappy: '>=1.1.10,<2.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-15.0.0-h33d03ac_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-15.0.2-h878f99b_1_cpu.conda
   hash:
-    md5: 442db6c705a47269dcecf50900903105
-    sha256: 2d7f88fcff1ac315596736ae7b564b59f856a488626e0c1727a22e21a43b4696
+    md5: a22f43ca465278c992639603c2b8e48c
+    sha256: b2a67b9ef9526da159b9fb64d225c4f4121cde176bcd1fc38617fd7935c0a9b5
   category: main
   optional: false
 - name: libarrow-acero
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.0
+    libarrow: 15.0.2
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-15.0.0-h59595ed_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-acero-15.0.2-h59595ed_1_cpu.conda
   hash:
-    md5: 85d3e05ea2b427e879e486f09fb8cf54
-    sha256: 9f4d6efa5aca41337407601e4e451b5f84ac0f0f9e101d2477e9a22c86752b70
+    md5: b9423f0ec36b99f729aa890b6fb3c98d
+    sha256: 6bf96851b6451f5d3ede688d454a23e40e53bbceb1e56e6d30a538be451d126d
   category: main
   optional: false
 - name: libarrow-acero
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-64
   dependencies:
-    libarrow: 15.0.0
-    libcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-15.0.0-h000cb23_2_cpu.conda
+    libarrow: 15.0.2
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-acero-15.0.2-hd427752_1_cpu.conda
   hash:
-    md5: 03e7a31ef2679c53536b23ba81d1892a
-    sha256: 260c883c0315d22808a58c57d35bc4012537d21d7fd2912dbb91007f36da952c
+    md5: c0ebc15c626587f686000bd92be0700f
+    sha256: 35a25a398c21791d8a7806be09b5d02b505081839d7ae5f9dc888d60f3c0d205
   category: main
   optional: false
 - name: libarrow-acero
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libarrow: 15.0.0
-    libcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-15.0.0-h13dd4ca_2_cpu.conda
+    libarrow: 15.0.2
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-acero-15.0.2-hebf3989_1_cpu.conda
   hash:
-    md5: ec356b91c5ec02274f5e0d7915f01df0
-    sha256: 31b3e352bc77ec9fd39ae9929490c70523ae18afc2244dd71fb5732f8d863af4
+    md5: 4af17aab0040bd8e02d8f91c67f72531
+    sha256: ce7352d970ad52d1e1bbf808d79b7632b8bc6f09155e22496520d9db7d188725
   category: main
   optional: false
 - name: libarrow-acero
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: win-64
   dependencies:
-    libarrow: 15.0.0
+    libarrow: 15.0.2
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-15.0.0-h63175ca_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-acero-15.0.2-h63175ca_1_cpu.conda
   hash:
-    md5: 5c32de6a0fa72e4940c7c318168e2987
-    sha256: 534f6a93a57c482c23562b4ff92c113570db139fbcdda350d2a6930ce1f3ff2e
+    md5: 1760e0c37e7b61989f3a23067721f84e
+    sha256: bb9a0f2585dd122ac9d4150215cbdc4a835cee0595aa8f4d094cb98b6a0b903f
   category: main
   optional: false
 - name: libarrow-dataset
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
     libgcc-ng: '>=12'
-    libparquet: 15.0.0
+    libparquet: 15.0.2
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-15.0.0-h59595ed_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-dataset-15.0.2-h59595ed_1_cpu.conda
   hash:
-    md5: 3cda69f7af9b2341e3ee0fb602861726
-    sha256: 487e036ad2a8f1cd34505ee53d169cd369fd6bca103b6bec1fc07526a98b8b5b
+    md5: a921e87ad731a7cde36a016233c1b80b
+    sha256: 41610da5423d6f167791b9dcf670151d53dbe545092e95efafd68dbf4437e6b1
   category: main
   optional: false
 - name: libarrow-dataset
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libcxx: '>=14'
-    libparquet: 15.0.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-15.0.0-h000cb23_2_cpu.conda
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libcxx: '>=16'
+    libparquet: 15.0.2
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-dataset-15.0.2-hd427752_1_cpu.conda
   hash:
-    md5: 8efe570ba59daac92a424eefd46f954c
-    sha256: 87df75a0e11dc2f90872fc822ea5b3d556f1800cd10e4f384dacd2212021e21f
+    md5: afb8fa396c1963637ab416acccf9c833
+    sha256: 4b0ea6e2c18c6add7e276447b751e09b20289d4bc672857abc05a525c138b532
   category: main
   optional: false
 - name: libarrow-dataset
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libcxx: '>=14'
-    libparquet: 15.0.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-15.0.0-h13dd4ca_2_cpu.conda
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libcxx: '>=16'
+    libparquet: 15.0.2
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-dataset-15.0.2-hebf3989_1_cpu.conda
   hash:
-    md5: 65f27b2cea74c85ffe0e5ad58fd04fdb
-    sha256: 61d89fe4677a3f4393cb8806ad8c3a7f78ec161720aae5d811d73bf20b109398
+    md5: 6d30f16616e83eedb5866c2c1be33846
+    sha256: 10d2a45fcb63a0750afbd15231647be8fb1944d2a6be78a5493ed848dfd30074
   category: main
   optional: false
 - name: libarrow-dataset
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: win-64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libparquet: 15.0.0
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libparquet: 15.0.2
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-15.0.0-h63175ca_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-dataset-15.0.2-h63175ca_1_cpu.conda
   hash:
-    md5: 64757dc8ae599dfb0cf819ef8772943f
-    sha256: 01c63d2da883e67433d73a24bc3d7232f6d41851b60cf5a28944584eca8f3c71
+    md5: e794000b8e1137d5cacbeba3811ecf3d
+    sha256: 68c8d5e01b3d404bd7c9b12d66cff1b03f8353c76d09c99e2a2f8ceecfcc094e
   category: main
   optional: false
 - name: libarrow-flight
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libarrow: 15.0.0
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libarrow: 15.0.2
     libgcc-ng: '>=12'
-    libgrpc: '>=1.60.0,<1.61.0a0'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
+    libgrpc: '>=1.62.1,<1.63.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libstdcxx-ng: '>=12'
     ucx: '>=1.15.0,<1.16.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-15.0.0-hdc44a87_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-15.0.2-hc6145d9_1_cpu.conda
   hash:
-    md5: 41f4c79b79d6c13ffb7abc71ab4f0c54
-    sha256: 95c656bc4c8120924619256939dc51ba1c8d226c757243b4a728c1de6bd1ec93
+    md5: a8166c3e9ff1222307cdd86af0234dbe
+    sha256: 0524b7b92b6d3ab5b043f5e3ea57291aec8fe69813191819bfd9e74bdcedfa1d
   category: main
   optional: false
 - name: libarrow-flight
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libarrow: 15.0.0
-    libcxx: '>=14'
-    libgrpc: '>=1.60.0,<1.61.0a0'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-15.0.0-h949774c_2_cpu.conda
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libarrow: 15.0.2
+    libcxx: '>=16'
+    libgrpc: '>=1.62.1,<1.63.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-15.0.2-h39e3226_1_cpu.conda
   hash:
-    md5: 14f9b17e3ceb2401c02604c475e26ab4
-    sha256: eaf259ad59b306a5e687301f4c8fc609c6f07cbba9389661f27888e579b21743
+    md5: 4c10ac4396926e3b262a07fe7a4b85e6
+    sha256: 6b12aca956d1c300a03fc3e25bd5b741a84f516dc2fe8d765350555d05126bd7
   category: main
   optional: false
 - name: libarrow-flight
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libarrow: 15.0.0
-    libcxx: '>=14'
-    libgrpc: '>=1.60.0,<1.61.0a0'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-15.0.0-h7c660a6_2_cpu.conda
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libarrow: 15.0.2
+    libcxx: '>=16'
+    libgrpc: '>=1.62.1,<1.63.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-15.0.2-h1f98dca_1_cpu.conda
   hash:
-    md5: 480bfd824d6430ef77e5c420141fd15a
-    sha256: 6f545baa7af0ce7f9745f22178400fca90dd7f6b5ead8b51a610a8398d0383fe
+    md5: de5f524a8661df4aa5aa3ee3298a5d5a
+    sha256: fe1f40d20c1f9c8c7828c77311953773da8b790372ddd2a7546eedc412c7e55b
   category: main
   optional: false
 - name: libarrow-flight
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: win-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libarrow: 15.0.0
-    libgrpc: '>=1.60.0,<1.61.0a0'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libarrow: 15.0.2
+    libgrpc: '>=1.62.1,<1.63.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-15.0.0-he112ba8_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-15.0.2-h02312f3_1_cpu.conda
   hash:
-    md5: 5654ebaf8fccea4136cdca3986a453d0
-    sha256: 9532feabdf08cd089fdbaf34f048f0176873b903c1e856e773791cdbfbd536b1
+    md5: 8bc6c812f84251b654b3db070d9b72ad
+    sha256: 9e5f73153ed5ee20431943a11e5aee79674bded2584b614d4e4d5962c7a35a64
   category: main
   optional: false
 - name: libarrow-flight-sql
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-flight: 15.0.0
+    libarrow: 15.0.2
+    libarrow-flight: 15.0.2
     libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-15.0.0-hfbc7f12_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-flight-sql-15.0.2-h757c851_1_cpu.conda
   hash:
-    md5: d779a1334ac200d6e9c04ee6bfa2a6af
-    sha256: ffe342e9fc4f570d8c491582a1d77781f05d5321fab665de79a7db2b588ef573
+    md5: b59b90d6c8d2e072890f5d289f9ba36f
+    sha256: 5d2910012453c698657a2129c9d3337d4569d79a23cf93b40ada013777a04798
   category: main
   optional: false
 - name: libarrow-flight-sql
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libarrow: 15.0.0
-    libarrow-flight: 15.0.0
-    libcxx: '>=14'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-15.0.0-he85462c_2_cpu.conda
+    libarrow: 15.0.2
+    libarrow-flight: 15.0.2
+    libcxx: '>=16'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-flight-sql-15.0.2-h1a3ed6a_1_cpu.conda
   hash:
-    md5: 7d10b24bc97206343d97015d9383ca16
-    sha256: 5756362693fb78d8f00a6a139dfca744ba3e16b6ea517fb4cbdc6d46475483dc
+    md5: fa369c66520f1ada8738fbf15ef0ee50
+    sha256: ab67e0202ca0565561eedf5c16d61b8bdf4302034bfad78b385574a74406fa7e
   category: main
   optional: false
 - name: libarrow-flight-sql
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-flight: 15.0.0
-    libcxx: '>=14'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-15.0.0-h6dff610_2_cpu.conda
+    libarrow: 15.0.2
+    libarrow-flight: 15.0.2
+    libcxx: '>=16'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-flight-sql-15.0.2-hb095944_1_cpu.conda
   hash:
-    md5: ecac5387b5800f247176696c208c5d1c
-    sha256: d769c352dd13e6593e3d82724886c39846c4189e5939c5ac42641a1f03436026
+    md5: 2c27f67068750b9a2ca0d795f53c2b35
+    sha256: 0cc6640c70f3b3c061a85dc88673674d3606d05f8fd69d1391f31f33711d663f
   category: main
   optional: false
 - name: libarrow-flight-sql
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: win-64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-flight: 15.0.0
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
+    libarrow: 15.0.2
+    libarrow-flight: 15.0.2
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-15.0.0-h8f0bfdc_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-flight-sql-15.0.2-h55b4db4_1_cpu.conda
   hash:
-    md5: 578d09838ccbb78cab2c3a6c499adb18
-    sha256: c73cee08997731bf4c28b2c9f7309c583b2681e90a5a6444d00abea067dd78d5
+    md5: 19d5af0b9e0adbb702969a5f75f9596f
+    sha256: 7954820f6e8d924419a372d90db68c1aa707101dbf9dc0204497597f831adab8
   category: main
   optional: false
 - name: libarrow-gandiva
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.0
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libarrow: 15.0.2
     libgcc-ng: '>=12'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    libllvm16: '>=16.0.6,<16.1.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libstdcxx-ng: '>=12'
     libutf8proc: '>=2.8.0,<3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-15.0.0-hacb8726_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-gandiva-15.0.2-hb016d2e_1_cpu.conda
   hash:
-    md5: d8415318348d02dad131144d6fc151ec
-    sha256: a5db33832e07e1a1cfff0069cf2bdf10b3f16209282b3d34a7eb5fec260b1134
+    md5: c595407620b1688599908bdc1c17fd74
+    sha256: 1e528b63285fd1918495e9b2ba83ece291ef0d53060b9120bb2af3591b53ffdd
   category: main
   optional: false
 - name: libarrow-gandiva
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-64
   dependencies:
-    libarrow: 15.0.0
-    libcxx: '>=14'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    __osx: '>=10.13'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libarrow: 15.0.2
+    libcxx: '>=16'
+    libllvm16: '>=16.0.6,<16.1.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libutf8proc: '>=2.8.0,<3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-15.0.0-h01dce7f_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-gandiva-15.0.2-h43798cf_1_cpu.conda
   hash:
-    md5: a5ae1f7435363fc38819f321b950cdde
-    sha256: f4c106381dd83d931b159e2f99adf21ea416741843066778ecac1e2767b4e8e1
+    md5: bc579bbc786f9c0a58b249e2adb0b26e
+    sha256: 95f3ea92b602de66fe03b09ad8718659503cadf3e424fd7e40a5949d9573f9ea
   category: main
   optional: false
 - name: libarrow-gandiva
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libarrow: 15.0.0
-    libcxx: '>=14'
-    libllvm15: '>=15.0.7,<15.1.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libarrow: 15.0.2
+    libcxx: '>=16'
+    libllvm16: '>=16.0.6,<16.1.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libutf8proc: '>=2.8.0,<3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-15.0.0-hf757142_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-gandiva-15.0.2-h2c81988_1_cpu.conda
   hash:
-    md5: 9ae243f3502e644e69fc508a065bfbcb
-    sha256: d3c0f787ae365524bc1f8bc81c87276896e54519ae08cb447b1347f3d061c719
+    md5: 8e4129c57f543cfb96c248f57a0fc484
+    sha256: 20fb6551040f1247db4bb6014d054b367647b2e12a017c59492dbb385bab05ca
   category: main
   optional: false
 - name: libarrow-gandiva
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: win-64
   dependencies:
-    libarrow: 15.0.0
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libarrow: 15.0.2
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libutf8proc: '>=2.8.0,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
@@ -7189,79 +5167,80 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-15.0.0-hb2eaab1_2_cpu.conda
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-gandiva-15.0.2-h3f2ff47_1_cpu.conda
   hash:
-    md5: 5c4ae8956e92997685b42be74944bd17
-    sha256: ee6e7efb6aac53c780b9ffd7e6573d43d9cbcf76a4223c4ff129a94ff627fc3e
+    md5: 68d3eaa519881658b9a8fbdddb1b3a0d
+    sha256: ff32757e31319f82b059be869b9e6fad1a65ccaa644263f8a30d5cf4ac0d20e2
   category: main
   optional: false
 - name: libarrow-substrait
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libarrow-dataset: 15.0.0
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libarrow-dataset: 15.0.2
     libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-15.0.0-hfbc7f12_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libarrow-substrait-15.0.2-h757c851_1_cpu.conda
   hash:
-    md5: 21de7bd8fd4568ccb232bc7bfbf3d112
-    sha256: e81cc5e7025ee02d971ded36c6030f65dfae044b7184fb9c75cb11451278e690
+    md5: 802e115e2c489e1c76c0fe809e766ccd
+    sha256: c4d7e0e2753eb193144b18ca78699d92da2a76011c3441952393ee672d1b9e32
   category: main
   optional: false
 - name: libarrow-substrait
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libarrow-dataset: 15.0.0
-    libcxx: '>=14'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-15.0.0-he85462c_2_cpu.conda
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libarrow-dataset: 15.0.2
+    libcxx: '>=16'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libarrow-substrait-15.0.2-h1a3ed6a_1_cpu.conda
   hash:
-    md5: ca385ed580c4ed97f1ea8dcd88d96e31
-    sha256: ba5c4f20a49c59fbc314a4e599c3e02c68369f4575aee35b5bf6f89efa820e7c
+    md5: e3c034db160f4604bd11028c3d825fa6
+    sha256: 6cf5535189e7bd3bf20ebef56381ab8bd161543228a851f5285ead9736477f33
   category: main
   optional: false
 - name: libarrow-substrait
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libarrow-dataset: 15.0.0
-    libcxx: '>=14'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-15.0.0-h3c8a37a_2_cpu.conda
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libarrow-dataset: 15.0.2
+    libcxx: '>=16'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libarrow-substrait-15.0.2-h50959cf_1_cpu.conda
   hash:
-    md5: 62ceeb6ee3403c3bfd8058c0e5e7e735
-    sha256: 945d2c83fc8245dcdbc1e5d0795fe41b3e624e62f07fd1eb00c5662981bd0126
+    md5: 01d6dc3a660a0f714ef6298be80eef39
+    sha256: fd44319e0b3ee61166d475fd02c857c3ead54c610090d7859a43e8f447f47501
   category: main
   optional: false
 - name: libarrow-substrait
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: win-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libarrow-dataset: 15.0.0
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libarrow-dataset: 15.0.2
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-15.0.0-h7aa34db_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libarrow-substrait-15.0.2-h89268de_1_cpu.conda
   hash:
-    md5: 3c2599f559574b2b3a8e777f9e6d3742
-    sha256: 6a46a0941a9e91a8dca84bf022b968ccd0ead69b3c7179928e67b450a6028cf2
+    md5: 99a787c11d708974eb7adde145591136
+    sha256: fd0c01546dec8d2cc8bfd6f88d80c961ca92f04872bda0441c4320cd4df6ed20
   category: main
   optional: false
 - name: libblas
@@ -7317,10 +5296,10 @@ package:
   manager: conda
   platform: linux-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libboost-headers-1.84.0-ha770c72_2.conda
   hash:
-    md5: 63a2690ffde5448bd8bbf19b5d1d366c
-    sha256: f5ac6b12768e5c735d2c8e4e1e05093b105d649a68f02f6a5349f5cb61719b9c
+    md5: 85d30a3fcc0f1cfc252776208af546a1
+    sha256: 5a7843db33422d043256af27f288836f51530b058653bdb074704eb72282f601
   category: main
   optional: false
 - name: libboost-headers
@@ -7328,10 +5307,10 @@ package:
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.84.0-h694c41f_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libboost-headers-1.84.0-h694c41f_2.conda
   hash:
-    md5: 530c932ca58015980579dbd0dbc7001e
-    sha256: cbe9834e3ea802ae6ab98ecde36d9840afd1bca768aabcb766a237124abcdfa2
+    md5: 37678c6938655e8862e121b48101365a
+    sha256: e51f3b877ab4a7a68bf1e1f95e9b007d716e85547078bfd5f6f7f114545dc26e
   category: main
   optional: false
 - name: libboost-headers
@@ -7339,10 +5318,10 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.84.0-hce30654_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libboost-headers-1.84.0-hce30654_2.conda
   hash:
-    md5: 6e665d044322dfffd437d7c6090e64f2
-    sha256: 006d0e4e266b806eb2280c6e3250e79a011428c21a706ee7d3e4251f66d1f278
+    md5: bf16112d5337a9a80d7126ac3a2cee7c
+    sha256: 2850952cc521318b6a5b18d8f55c86149b779a9103cca9875ff128ce9b6d6400
   category: main
   optional: false
 - name: libboost-headers
@@ -7350,10 +5329,10 @@ package:
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.84.0-h57928b3_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libboost-headers-1.84.0-h57928b3_2.conda
   hash:
-    md5: 28b61d8b072ee3b7a7596a02a0b2c9df
-    sha256: 790ad368444ab7f64eee4060e42a13323b11fe435629d06cb6a84d4a471ac8eb
+    md5: 01d545c5fbafd05719fa31148cbd1989
+    sha256: 9acabbc9bf68f89ff60aa06e622b1bdf20edc7b3f53bfc782135f0ea9882291f
   category: main
   optional: false
 - name: libbrotlicommon
@@ -7607,7 +5586,7 @@ package:
   category: main
   optional: false
 - name: libcurl
-  version: 8.5.0
+  version: 8.7.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -7616,16 +5595,16 @@ package:
     libnghttp2: '>=1.58.0,<2.0a0'
     libssh2: '>=1.11.0,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.5.0-hca28451_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.7.1-hca28451_0.conda
   hash:
-    md5: 7144d5a828e2cae218e0e3c98d8a0aeb
-    sha256: 00a6bea5ff90ca58eeb15ebc98e08ffb88bddaff27396bb62640064f59d29cf0
+    md5: 755c7f876815003337d2c61ff5d047e5
+    sha256: 82a75e9a5d9ee5b2f487d850ec5d4edc18a56eb9527608a95a916c40baae3843
   category: main
   optional: false
 - name: libcurl
-  version: 8.5.0
+  version: 8.7.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -7633,16 +5612,16 @@ package:
     libnghttp2: '>=1.58.0,<2.0a0'
     libssh2: '>=1.11.0,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.5.0-h726d00d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcurl-8.7.1-h726d00d_0.conda
   hash:
-    md5: 86d749e27fe00fa6b7d790a6feaa22a2
-    sha256: 7ec7e026be90da0965dfa6b92bbc905c852c13b27f3f83c47156db66ed0668f0
+    md5: fa58e5eaa12006bc3289a71357bef167
+    sha256: 06cb1bd3bbaf905213777d6ade190ac4c7fb7a20dfe0cf901c977dbbc6cec265
   category: main
   optional: false
 - name: libcurl
-  version: 8.5.0
+  version: 8.7.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -7650,16 +5629,16 @@ package:
     libnghttp2: '>=1.58.0,<2.0a0'
     libssh2: '>=1.11.0,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.5.0-h2d989ff_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcurl-8.7.1-h2d989ff_0.conda
   hash:
-    md5: f1211ed00947a84e15a964a8f459f620
-    sha256: f1c04be217aaf161ce3c99a8d618871295b5dc1eae2f7ff7b32078af50303f5b
+    md5: 34b9171710f0d9bf093d55bdc36ff355
+    sha256: 973ac9368efca712a8fd19fe68524d7d9a3087fd88ad6b7fcdf60c3d2e19a498
   category: main
   optional: false
 - name: libcurl
-  version: 8.5.0
+  version: 8.7.1
   manager: conda
   platform: win-64
   dependencies:
@@ -7669,10 +5648,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.5.0-hd5e4a3a_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libcurl-8.7.1-hd5e4a3a_0.conda
   hash:
-    md5: c95eb3d60266dd47b8eb864e10d6bcf3
-    sha256: 8c933416c61445ab51515a5ca8c32ddc4f83180d5dc43684e4a80915022ffe1f
+    md5: 3396aff340d0903e8814c2852d631e4e
+    sha256: 8dd272362e2aeb1d4f49333ff57e07eb4da2bbabce20110a2416df9152ba03e0
   category: main
   optional: false
 - name: libcxx
@@ -7698,51 +5677,51 @@ package:
   category: main
   optional: false
 - name: libdeflate
-  version: '1.19'
+  version: '1.20'
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.19-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.20-hd590300_0.conda
   hash:
-    md5: 1635570038840ee3f9c71d22aa5b8b6d
-    sha256: 985ad27aa0ba7aad82afa88a8ede6a1aacb0aaca950d710f15d85360451e72fd
+    md5: 8e88f9389f1165d7c0936fe40d9a9a79
+    sha256: f8e0f25c382b1d0b87a9b03887a34dbd91485453f1ea991fef726dba57373612
   category: main
   optional: false
 - name: libdeflate
-  version: '1.19'
+  version: '1.20'
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.19-ha4e1b8e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libdeflate-1.20-h49d49c5_0.conda
   hash:
-    md5: 6a45f543c2beb40023df5ee7e3cedfbd
-    sha256: d0f789120fedd0881b129aba9993ec5dcf0ecca67a71ea20c74394e41adcb503
+    md5: d46104f6a896a0bc6a1d37b88b2edf5c
+    sha256: 8c2087952db55c4118dd2e29381176a54606da47033fd61ebb1b0f4391fcd28d
   category: main
   optional: false
 - name: libdeflate
-  version: '1.19'
+  version: '1.20'
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.19-hb547adb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libdeflate-1.20-h93a5062_0.conda
   hash:
-    md5: f8c1eb0e99e90b55965c6558578537cc
-    sha256: 6a3d188a6ae845a742dc85c5fb3f7eb1e252726cd74f0b8a7fa25ec09db6b87a
+    md5: 97efeaeba2a9a82bdf46fc6d025e3a57
+    sha256: 6d16cccb141b6bb05c38107b335089046664ea1d6611601d3f6e7e4227a99925
   category: main
   optional: false
 - name: libdeflate
-  version: '1.19'
+  version: '1.20'
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.19-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.20-hcfcfb64_0.conda
   hash:
-    md5: 002b1b723b44dbd286b9e3708762433c
-    sha256: e2886a84eaa0fbeca1d1d810270f234431d190402b4a79acf756ca2d16000354
+    md5: b12b5bde5eb201a1df75e49320cc938a
+    sha256: 6628a5b76ad70c1a0909563c637ddc446ee824739ba7c348d4da2f0aa6ac9527
   category: main
   optional: false
 - name: libedit
@@ -7869,48 +5848,48 @@ package:
   category: main
   optional: false
 - name: libexpat
-  version: 2.5.0
+  version: 2.6.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.5.0-hcb278e6_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
   hash:
-    md5: 6305a3dd2752c76335295da4e581f2fd
-    sha256: 74c98a563777ae2ad71f1f74d458a8ab043cee4a513467c159ccf159d0e461f3
+    md5: e7ba12deb7020dd080c6c70e7b6f6a3d
+    sha256: 331bb7c7c05025343ebd79f86ae612b9e1e74d2687b8f3179faec234f986ce19
   category: main
   optional: false
 - name: libexpat
-  version: 2.5.0
+  version: 2.6.2
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.5.0-hf0c8a7f_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
   hash:
-    md5: 6c81cb022780ee33435cca0127dd43c9
-    sha256: 80024bd9f44d096c4cc07fb2bac76b5f1f7553390112dab3ad6acb16a05f0b96
+    md5: 3d1d51c8f716d97c864d12f7af329526
+    sha256: a188a77b275d61159a32ab547f7d17892226e7dac4518d2c6ac3ac8fc8dfde92
   category: main
   optional: false
 - name: libexpat
-  version: 2.5.0
+  version: 2.6.2
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.5.0-hb7217d7_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
   hash:
-    md5: 5a097ad3d17e42c148c9566280481317
-    sha256: 7d143a9c991579ad4207f84c632650a571c66329090daa32b3c87cf7311c3381
+    md5: e3cde7cfa87f82f7cb13d482d5e0ad09
+    sha256: ba7173ac30064ea901a4c9fb5a51846dcc25512ceb565759be7d18cbf3e5415e
   category: main
   optional: false
 - name: libexpat
-  version: 2.5.0
+  version: 2.6.2
   manager: conda
   platform: win-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.5.0-h63175ca_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.6.2-h63175ca_0.conda
   hash:
-    md5: 636cc3cbbd2e28bcfd2f73b2044aac2c
-    sha256: 794b2a9be72f176a2767c299574d330ffb76b2ed75d7fd20bee3bbadce5886cf
+    md5: bc592d03f62779511d392c175dcece64
+    sha256: 79f612f75108f3e16bbdc127d4885bb74729cf66a8702fca0373dad89d40c4b7
   category: main
   optional: false
 - name: libffi
@@ -7974,13 +5953,13 @@ package:
   category: main
   optional: false
 - name: libgdal
-  version: 3.8.3
+  version: 3.8.4
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     blosc: '>=1.21.5,<2.0a0'
-    cfitsio: '>=4.3.1,<4.3.2.0a0'
+    cfitsio: '>=4.4.0,<4.4.1.0a0'
     freexl: '>=2.0.0,<3.0a0'
     geos: '>=3.12.1,<3.12.2.0a0'
     geotiff: '>=1.7.1,<1.8.0a0'
@@ -7990,50 +5969,50 @@ package:
     json-c: '>=0.17,<0.18.0a0'
     kealib: '>=1.5.3,<1.6.0a0'
     lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.2,<2.0a0'
+    libaec: '>=1.1.3,<2.0a0'
     libarchive: '>=3.7.2,<3.8.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libdeflate: '>=1.19,<1.20.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
+    libdeflate: '>=1.20,<1.21.0a0'
+    libexpat: '>=2.6.2,<3.0a0'
     libgcc-ng: '>=12'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
-    libpq: '>=16.1,<17.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libpq: '>=16.2,<17.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.2,<4.0a0'
     libstdcxx-ng: '>=12'
     libtiff: '>=4.6.0,<4.7.0a0'
     libuuid: '>=2.38.1,<3.0a0'
     libwebp-base: '>=1.3.2,<2.0a0'
-    libxml2: '>=2.12.5,<3.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     openssl: '>=3.2.1,<4.0a0'
-    pcre2: '>=10.42,<10.43.0a0'
-    poppler: '>=24.2.0,<24.3.0a0'
+    pcre2: '>=10.43,<10.44.0a0'
+    poppler: '>=24.3.0,<24.4.0a0'
     postgresql: ''
     proj: '>=9.3.1,<9.3.2.0a0'
-    tiledb: '>=2.19.1,<2.20.0a0'
+    tiledb: '>=2.21.1,<2.22.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.8.3-h80d7d79_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgdal-3.8.4-h7c88fdf_5.conda
   hash:
-    md5: b0c8bd68d3119c8e3a355ff9417ceff1
-    sha256: ab5cf0b7ebddb1543ebc129c3c031e5743afd7264cfce98385d6ff18f43a9140
+    md5: 750bfb344a8690e7089c8c2b303f252a
+    sha256: caad3fbd31a1572a5688d27bcf863acc36866eeaf73c4af67e5e40480e87772e
   category: main
   optional: false
 - name: libgdal
-  version: 3.8.3
+  version: 3.8.4
   manager: conda
   platform: osx-64
   dependencies:
     blosc: '>=1.21.5,<2.0a0'
-    cfitsio: '>=4.3.1,<4.3.2.0a0'
+    cfitsio: '>=4.4.0,<4.4.1.0a0'
     freexl: '>=2.0.0,<3.0a0'
     geos: '>=3.12.1,<3.12.2.0a0'
     geotiff: '>=1.7.1,<1.8.0a0'
@@ -8043,48 +6022,48 @@ package:
     json-c: '>=0.17,<0.18.0a0'
     kealib: '>=1.5.3,<1.6.0a0'
     lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.2,<2.0a0'
+    libaec: '>=1.1.3,<2.0a0'
     libarchive: '>=3.7.2,<3.8.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
     libcxx: '>=16'
-    libdeflate: '>=1.19,<1.20.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
+    libdeflate: '>=1.20,<1.21.0a0'
+    libexpat: '>=2.6.2,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
-    libpq: '>=16.1,<17.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libpq: '>=16.2,<17.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.2,<4.0a0'
     libtiff: '>=4.6.0,<4.7.0a0'
     libwebp-base: '>=1.3.2,<2.0a0'
-    libxml2: '>=2.12.5,<3.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     openssl: '>=3.2.1,<4.0a0'
-    pcre2: '>=10.42,<10.43.0a0'
-    poppler: '>=24.2.0,<24.3.0a0'
+    pcre2: '>=10.43,<10.44.0a0'
+    poppler: '>=24.3.0,<24.4.0a0'
     postgresql: ''
     proj: '>=9.3.1,<9.3.2.0a0'
-    tiledb: '>=2.19.1,<2.20.0a0'
+    tiledb: '>=2.21.1,<2.22.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.8.3-hf248df1_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgdal-3.8.4-h2239303_5.conda
   hash:
-    md5: e90cc4866da1256f6336aca6949d41aa
-    sha256: c8407dc01e07c6680a77813c9ef5176465f70f3b2ffe623a3f3ca922578cbcb3
+    md5: d38e6517611a9666774554c5124cfa44
+    sha256: 0840390bd7b68eb2eb2f4e0dd67730d4ed20709a56f7c0e338442faee8603ed6
   category: main
   optional: false
 - name: libgdal
-  version: 3.8.3
+  version: 3.8.4
   manager: conda
   platform: osx-arm64
   dependencies:
     blosc: '>=1.21.5,<2.0a0'
-    cfitsio: '>=4.3.1,<4.3.2.0a0'
+    cfitsio: '>=4.4.0,<4.4.1.0a0'
     freexl: '>=2.0.0,<3.0a0'
     geos: '>=3.12.1,<3.12.2.0a0'
     geotiff: '>=1.7.1,<1.8.0a0'
@@ -8094,48 +6073,48 @@ package:
     json-c: '>=0.17,<0.18.0a0'
     kealib: '>=1.5.3,<1.6.0a0'
     lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.2,<2.0a0'
+    libaec: '>=1.1.3,<2.0a0'
     libarchive: '>=3.7.2,<3.8.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
     libcxx: '>=16'
-    libdeflate: '>=1.19,<1.20.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
+    libdeflate: '>=1.20,<1.21.0a0'
+    libexpat: '>=2.6.2,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
-    libpq: '>=16.1,<17.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libpq: '>=16.2,<17.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.2,<4.0a0'
     libtiff: '>=4.6.0,<4.7.0a0'
     libwebp-base: '>=1.3.2,<2.0a0'
-    libxml2: '>=2.12.5,<3.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     openssl: '>=3.2.1,<4.0a0'
-    pcre2: '>=10.42,<10.43.0a0'
-    poppler: '>=24.2.0,<24.3.0a0'
+    pcre2: '>=10.43,<10.44.0a0'
+    poppler: '>=24.3.0,<24.4.0a0'
     postgresql: ''
     proj: '>=9.3.1,<9.3.2.0a0'
-    tiledb: '>=2.19.1,<2.20.0a0'
+    tiledb: '>=2.21.1,<2.22.0a0'
     xerces-c: '>=3.2.5,<3.3.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.8.3-hb4bbca3_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-3.8.4-h7181668_5.conda
   hash:
-    md5: ed38dcd4424c2a3ef348a70252e80149
-    sha256: f293a8a1d36fb6a62948c8ffa0578147e1c85d166a3acbfb3e754418deecdc88
+    md5: 795df87e28f1df475c180064e86e3917
+    sha256: 7bb93c93ab3264a22af70d3aa3787b11f4092a0dcb2b6f838bbf3c2e2ee5bfb2
   category: main
   optional: false
 - name: libgdal
-  version: 3.8.3
+  version: 3.8.4
   manager: conda
   platform: win-64
   dependencies:
     blosc: '>=1.21.5,<2.0a0'
-    cfitsio: '>=4.3.1,<4.3.2.0a0'
+    cfitsio: '>=4.4.0,<4.4.1.0a0'
     freexl: '>=2.0.0,<3.0a0'
     geos: '>=3.12.1,<3.12.2.0a0'
     geotiff: '>=1.7.1,<1.8.0a0'
@@ -8143,41 +6122,41 @@ package:
     hdf5: '>=1.14.3,<1.14.4.0a0'
     kealib: '>=1.5.3,<1.6.0a0'
     lerc: '>=4.0.0,<5.0a0'
-    libaec: '>=1.1.2,<2.0a0'
+    libaec: '>=1.1.3,<2.0a0'
     libarchive: '>=3.7.2,<3.8.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libdeflate: '>=1.19,<1.20.0a0'
-    libexpat: '>=2.5.0,<3.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
+    libdeflate: '>=1.20,<1.21.0a0'
+    libexpat: '>=2.6.2,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libkml: '>=1.3.0,<1.4.0a0'
     libnetcdf: '>=4.9.2,<4.9.3.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
-    libpq: '>=16.1,<17.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
+    libpq: '>=16.2,<17.0a0'
     libspatialite: '>=5.1.0,<5.2.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.2,<4.0a0'
     libtiff: '>=4.6.0,<4.7.0a0'
     libwebp-base: '>=1.3.2,<2.0a0'
-    libxml2: '>=2.12.5,<3.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     openssl: '>=3.2.1,<4.0a0'
-    pcre2: '>=10.42,<10.43.0a0'
-    poppler: '>=24.2.0,<24.3.0a0'
+    pcre2: '>=10.43,<10.44.0a0'
+    poppler: '>=24.3.0,<24.4.0a0'
     postgresql: ''
     proj: '>=9.3.1,<9.3.2.0a0'
-    tiledb: '>=2.19.1,<2.20.0a0'
+    tiledb: '>=2.21.1,<2.22.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     xerces-c: '>=3.2.5,<3.3.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.8.3-h0f7007b_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libgdal-3.8.4-hf83a0e2_5.conda
   hash:
-    md5: 358ef6414de9d3b725df7ab2a9766d3b
-    sha256: 108601d60189c8c3ba7708776690481dedf770e5dc2ea9f197cef4ab7d088dc0
+    md5: 0efb428de61baca5231bdf6ef0a4de2d
+    sha256: 98e0e290f8cc76e66a386283240e35158bd22960b18301a7ca281a2aecaba01b
   category: main
   optional: false
 - name: libgfortran
@@ -8253,76 +6232,69 @@ package:
   category: main
   optional: false
 - name: libglib
-  version: 2.78.3
+  version: 2.80.0
   manager: conda
   platform: linux-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
     libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
     libiconv: '>=1.17,<2.0a0'
-    libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-    pcre2: '>=10.42,<10.43.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.78.3-h783c2da_0.conda
+    pcre2: '>=10.43,<10.44.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.80.0-hf2295e7_1.conda
   hash:
-    md5: 9bd06b12bbfa6fd1740fd23af4b0f0c7
-    sha256: b1b594294a0fe4c9a51596ef027efed9268d60827e8ae61fb7545c521a631e33
+    md5: 0725f6081030c29b109088639824ff90
+    sha256: 636d984568a1e5d915098a5020712f82bb3988635015765c3caf70f1a91340c5
   category: main
   optional: false
 - name: libglib
-  version: 2.78.3
+  version: 2.80.0
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.9'
     gettext: '>=0.21.1,<1.0a0'
-    libcxx: '>=16.0.6'
     libffi: '>=3.4,<4.0a0'
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    pcre2: '>=10.42,<10.43.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.78.3-h198397b_0.conda
+    pcre2: '>=10.43,<10.44.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libglib-2.80.0-h81c1438_1.conda
   hash:
-    md5: e18624e441743b0d744116885b70f092
-    sha256: 90e58879873b05617e0678ecfbf47bc740c1a2ed7840b8f7cd1241813b9037db
+    md5: e1c7ad2617b7ebe7589e87024d90ddda
+    sha256: 5bc911f8c29878252f14dfc08fcf72cf550038a7102f9c03612fee9f7ccf6234
   category: main
   optional: false
 - name: libglib
-  version: 2.78.3
+  version: 2.80.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
     gettext: '>=0.21.1,<1.0a0'
-    libcxx: '>=16.0.6'
     libffi: '>=3.4,<4.0a0'
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    pcre2: '>=10.42,<10.43.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.78.3-hb438215_0.conda
+    pcre2: '>=10.43,<10.44.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libglib-2.80.0-hfc324ee_1.conda
   hash:
-    md5: 8c98b7018b434236e2c0f14d7cf3c113
-    sha256: f26afb1003e810e768138b0c849e9408c0ae8635062aeaf7abae381903a84e53
+    md5: 3d8a5773a6ba1be1db8dc23ea9f44a0a
+    sha256: b7411c3b19681fea1a33c093364cb2d8a021a408133399b23c947231aac157d9
   category: main
   optional: false
 - name: libglib
-  version: 2.78.3
+  version: 2.80.0
   manager: conda
   platform: win-64
   dependencies:
-    gettext: '>=0.21.1,<1.0a0'
     libffi: '>=3.4,<4.0a0'
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    pcre2: '>=10.42,<10.43.0a0'
+    pcre2: '>=10.43,<10.44.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.78.3-h16e383f_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libglib-2.80.0-h39d0aa6_1.conda
   hash:
-    md5: c295badd19494ac8476b36e9e9e47ace
-    sha256: 33527a11321609064c649682e709ebede86e24f1264dac1d018aaa00fb3b90bf
+    md5: 6160439f169ec670951460024751b2ae
+    sha256: 326fb2d1c8789660cec01eda3eec2fa15dd816d291126df13f1c34d80ffda6aa
   category: main
   optional: false
 - name: libgomp
@@ -8338,159 +6310,230 @@ package:
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.12.0
+  version: 2.22.0
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libcurl: '>=8.5.0,<9.0a0'
     libgcc-ng: '>=12'
-    libgrpc: '>=1.60.0,<1.61.0a0'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
+    libgrpc: '>=1.62.0,<1.63.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libstdcxx-ng: '>=12'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.12.0-hef10d8f_5.conda
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-2.22.0-h9be4e54_1.conda
   hash:
-    md5: 055e2266d27f0e2290cf0a6ad668a225
-    sha256: 3c80f8da632c01b5beb50bdc4c7c488501793cd7c138427f61e93f98719e8342
+    md5: 4b4e36a91e7dabf7345b82d85767a7c3
+    sha256: b9980209438b22113f4352df2b260bf43b2eb63a7b6325192ec5ae3a562872ed
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.12.0
+  version: 2.22.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libcurl: '>=8.5.0,<9.0a0'
-    libcxx: '>=15'
-    libgrpc: '>=1.60.0,<1.61.0a0'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.12.0-he77a663_5.conda
+    libcxx: '>=16'
+    libgrpc: '>=1.62.0,<1.63.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-2.22.0-h651e89d_1.conda
   hash:
-    md5: dac48d8fadf9e28c7010f49b56804862
-    sha256: 4cae7eefaeba18daf87f046c1e26026f741d1c3f0f0740bf082e3dbd8454ac67
+    md5: 3f2faf53ecb3b51b92b3eee155b50233
+    sha256: 39f2f50202e50e41ee8581c99a0b3023c2c21cab80ba597f8c5be7c8c8c6a059
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.12.0
+  version: 2.22.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libcurl: '>=8.5.0,<9.0a0'
-    libcxx: '>=15'
-    libgrpc: '>=1.60.0,<1.61.0a0'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-    openssl: '>=3.2.0,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.12.0-h49bbb43_5.conda
+    libcxx: '>=16'
+    libgrpc: '>=1.62.0,<1.63.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-2.22.0-hbebe991_1.conda
   hash:
-    md5: d692ffaa8a4c54936205b7f794596c2c
-    sha256: bedf55e777aafb89a371bf0322f15bff952a620278920c100177d61e37aecca9
+    md5: ec7ea95b08e8cbc39fa16b6eafee36e6
+    sha256: a114b4d46eebede7e514abaf9203ea8c952a6382c5c57d1b989da062e3899bd7
   category: main
   optional: false
 - name: libgoogle-cloud
-  version: 2.12.0
+  version: 2.22.0
   manager: conda
   platform: win-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libcurl: '>=8.5.0,<9.0a0'
-    libgrpc: '>=1.60.0,<1.61.0a0'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    libgrpc: '>=1.62.0,<1.63.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.12.0-hc7cbac0_5.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-2.22.0-h9cad5c0_1.conda
   hash:
-    md5: 1f219361b6f83f8e7ab4d2c67ff06ce4
-    sha256: 03f360345841ecb6cdc6a3a3a75a04e29d2f53e5fc180822d9ebef5d131a9007
+    md5: 63cd44a71f00d4e72844bf0e8be56be4
+    sha256: f76e892d13e1db405777c968787678d8ba912b7e4eef7f950fcdcca185e06e71
   category: main
   optional: false
-- name: libgrpc
-  version: 1.60.1
+- name: libgoogle-cloud-storage
+  version: 2.22.0
   manager: conda
   platform: linux-64
   dependencies:
-    c-ares: '>=1.26.0,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
+    libabseil: ''
+    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libcurl: ''
     libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    libgoogle-cloud: 2.22.0
+    libstdcxx-ng: '>=12'
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgoogle-cloud-storage-2.22.0-hc7a4891_1.conda
+  hash:
+    md5: 7811f043944e010e54640918ea82cecd
+    sha256: 0e00e1ca2a981db1c96071edf266bc29fd6f13ac484225de1736fc4dac5c64a8
+  category: main
+  optional: false
+- name: libgoogle-cloud-storage
+  version: 2.22.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libabseil: ''
+    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libcurl: ''
+    libcxx: '>=16'
+    libgoogle-cloud: 2.22.0
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-storage-2.22.0-ha67e85c_1.conda
+  hash:
+    md5: 0c25180c34b1a58d309b28386698fb6e
+    sha256: e4f351e55fe7c0656cb608eba8690063e3b407d25a855c9d1fd832486d4a1244
+  category: main
+  optional: false
+- name: libgoogle-cloud-storage
+  version: 2.22.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libabseil: ''
+    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libcurl: ''
+    libcxx: '>=16'
+    libgoogle-cloud: 2.22.0
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-storage-2.22.0-h8a76758_1.conda
+  hash:
+    md5: a89fb5b36b08efaae128d4933e593315
+    sha256: e23be5896fd78e0e8b1098aab8803192f0c4a328d3d30a57d20d80194045d793
+  category: main
+  optional: false
+- name: libgoogle-cloud-storage
+  version: 2.22.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    libabseil: ''
+    libcrc32c: '>=1.1.2,<1.2.0a0'
+    libcurl: ''
+    libgoogle-cloud: 2.22.0
+    libzlib: '>=1.2.13,<1.3.0a0'
+    openssl: ''
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-2.22.0-hb581fae_1.conda
+  hash:
+    md5: f63348292dea55cf834e631cf26e2669
+    sha256: 5ee34f168948211db14874f521e6edf9b4032d533c61fd429caaa282be1d0e7b
+  category: main
+  optional: false
+- name: libgrpc
+  version: 1.62.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    c-ares: '>=1.27.0,<2.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libgcc-ng: '>=12'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.60.1-h74775cd_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgrpc-1.62.1-h15f2491_0.conda
   hash:
-    md5: 5b7702c8961d99c949fb4f300a19c747
-    sha256: 66d776eda66e1d786160e03b4572c8dc9c8377a7f0abfca9a90643b64f1d150e
+    md5: 564517a8cbd095cff75eb996d33d2b7e
+    sha256: 1d4ece94dfef73d904dcba0fd9d56098796f5fdc62ea5f9edff60c71be7a3d63
   category: main
   optional: false
 - name: libgrpc
-  version: 1.60.1
+  version: 1.62.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    c-ares: '>=1.26.0,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
+    c-ares: '>=1.27.0,<2.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libcxx: '>=16'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.60.1-h038e8f1_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgrpc-1.62.1-h384b2fc_0.conda
   hash:
-    md5: 8eb56fb9779657380adcf4b68181bcf0
-    sha256: 4594e993e1ab0fafbee81cfe4ff6b3aea5684035a3244a9edac8e73a1f5da508
+    md5: 2ac05daca7276a4d6ca4465707670380
+    sha256: 8c9898d259e2343df52259b599ec342c386679e1c420df603cba6f06078fcdd6
   category: main
   optional: false
 - name: libgrpc
-  version: 1.60.1
+  version: 1.62.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    c-ares: '>=1.26.0,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
+    c-ares: '>=1.27.0,<2.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libcxx: '>=16'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     re2: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.60.1-hfc68871_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgrpc-1.62.1-h9c18a4f_0.conda
   hash:
-    md5: 2a083ed71f470c67d480eb03b393792c
-    sha256: dfc59f830629504342016514afe9927e2fa4784fc424a40452746c76ad025a8c
+    md5: 24f15c1a9e111825d39bf77881430107
+    sha256: b8c6b48430d0778e9452df88fa7c07fc7828aac87291372ac42dbe78be4078d5
   category: main
   optional: false
 - name: libgrpc
-  version: 1.60.1
+  version: 1.62.1
   manager: conda
   platform: win-64
   dependencies:
-    c-ares: '>=1.26.0,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-    libre2-11: '>=2023.6.2,<2024.0a0'
+    c-ares: '>=1.27.0,<2.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
+    libre2-11: '>=2023.9.1,<2024.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     re2: ''
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.60.1-h0bf0bfa_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.62.1-h5273850_0.conda
   hash:
-    md5: 18b66a3a1d8b0d10767e15b0e24fdaf6
-    sha256: 7b3dbadddc653ce72da4726a3d75fcd250e8a1e973879883ceae7ebee7d06f01
+    md5: 99ac2f772591801641ec692fee843796
+    sha256: 338cb58d1095ee651acd168af9636834b41908f7a94e613088e284dc53d2947c
   category: main
   optional: false
 - name: libhwloc
@@ -8720,8 +6763,8 @@ package:
     sha256: 3fa7c08dd4edf59cb0907d2e5b74e6be890e0671f845e1bae892d212d118a7e9
   category: main
   optional: false
-- name: libllvm15
-  version: 15.0.7
+- name: libllvm16
+  version: 16.0.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -8730,14 +6773,14 @@ package:
     libxml2: '>=2.12.1,<3.0.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm15-15.0.7-hb3ce162_4.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libllvm16-16.0.6-hb3ce162_3.conda
   hash:
-    md5: 8a35df3cbc0c8b12cc8af9473ae75eef
-    sha256: e71584c0f910140630580fdd0a013029a52fd31e435192aea2aa8d29005262d1
+    md5: a4d48c40dd5c60edbab7fd69c9a88967
+    sha256: 624fa4012397bc5a8c9269247bf9baa7d907eb59079aefc6f6fa6a40f10fd0ba
   category: main
   optional: false
-- name: libllvm15
-  version: 15.0.7
+- name: libllvm16
+  version: 16.0.6
   manager: conda
   platform: osx-64
   dependencies:
@@ -8745,24 +6788,25 @@ package:
     libxml2: '>=2.12.1,<3.0.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm15-15.0.7-hbedff68_4.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libllvm16-16.0.6-hbedff68_3.conda
   hash:
-    md5: bdc80cf2aa69d6eb8dd101dfd804db07
-    sha256: a0598cc166e92c6c63e58a7eaa184fa0b8b467693b965dbe19f1c9ff37e134c3
+    md5: 8fd56c0adc07a37f93bd44aa61a97c90
+    sha256: ad848dc0bb02b1dbe54324ee5700b050a2e5f63c095f5229b2de58249a3e268e
   category: main
   optional: false
-- name: libllvm15
-  version: 15.0.7
+- name: libllvm16
+  version: 16.0.6
   manager: conda
   platform: osx-arm64
   dependencies:
     libcxx: '>=16'
     libxml2: '>=2.12.1,<3.0.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm15-15.0.7-h2621b3d_4.conda
+    zstd: '>=1.5.5,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libllvm16-16.0.6-haab561b_3.conda
   hash:
-    md5: 8d7f7a7286d99a2671df2619cb3bfb2c
-    sha256: 63e22ccd4c1b80dfc7da169c65c62a878a46ef0e5771c3b0c091071e718ae1b1
+    md5: 9900d62ede9ce25b569beeeab1da094e
+    sha256: f240f3776b02c39a32ce7397d6f2de072510321c835f4def452fc62e5c3babc0
   category: main
   optional: false
 - name: libnetcdf
@@ -8940,18 +6984,6 @@ package:
     sha256: 26d77a3bb4dceeedc2a41bd688564fe71bf2d149fdcf117049970bc02ff1add6
   category: main
   optional: false
-- name: libnuma
-  version: 2.0.16
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnuma-2.0.16-h0b41bf4_1.conda
-  hash:
-    md5: 28bfe2cb11357ccc5be21101a6b7ce86
-    sha256: 814a50cba215548ec3ebfb53033ffb9b3b070b2966570ff44910b8d9ba1c359d
-  category: main
-  optional: false
 - name: libopenblas
   version: 0.3.26
   manager: conda
@@ -8995,107 +7027,107 @@ package:
   category: main
   optional: false
 - name: libparquet
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.0
+    libarrow: 15.0.2
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     libthrift: '>=0.19.0,<0.19.1.0a0'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-15.0.0-h352af49_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libparquet-15.0.2-h352af49_1_cpu.conda
   hash:
-    md5: 8d99909e413b67872996d46093dda024
-    sha256: 08ff511559a7b3390c393e8bdc61a40cb50ce7c94032553448eba5000ef98d8c
+    md5: 9c9171bf3a477a585d08a7979f84c3b8
+    sha256: 3561887d5cecd273ca4a40c7263b0b81b9fcb7d14c54fe83c1f691b86c1c6b6f
   category: main
   optional: false
 - name: libparquet
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-64
   dependencies:
-    libarrow: 15.0.0
-    libcxx: '>=14'
+    libarrow: 15.0.2
+    libcxx: '>=16'
     libthrift: '>=0.19.0,<0.19.1.0a0'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-15.0.0-h381d950_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libparquet-15.0.2-h089a9f7_1_cpu.conda
   hash:
-    md5: e2ad5efe2ca8216eb82f146075762bed
-    sha256: c5863eceea1d1e324d9c8a62476c39dbe4c917f0171333600c1fd217d84e1e26
+    md5: 1b06e76579f69227a285a574611f01d1
+    sha256: c018302a1cb5a7d499ee48639264970acbdb6046367a53d533fdd3dad6b9de11
   category: main
   optional: false
 - name: libparquet
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libarrow: 15.0.0
-    libcxx: '>=14'
+    libarrow: 15.0.2
+    libcxx: '>=16'
     libthrift: '>=0.19.0,<0.19.1.0a0'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-15.0.0-hf6ce1d5_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-15.0.2-h278d484_1_cpu.conda
   hash:
-    md5: 29a0fc4c74806e8cc5e0bd0c04b4a77a
-    sha256: 374ba422082569f53c8c1a598ec50f9c571668fb5c58ae1ec278c39c56e2c756
+    md5: 7896c2d5ff80f77554d1cbefae676d78
+    sha256: 7f464ccdbbf52032e4c21fbc4ee387bbabdbff1b0667e60d32c85fbd8b24f988
   category: main
   optional: false
 - name: libparquet
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: win-64
   dependencies:
-    libarrow: 15.0.0
+    libarrow: 15.0.2
     libthrift: '>=0.19.0,<0.19.1.0a0'
     openssl: '>=3.2.1,<4.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-15.0.0-h7ec3a38_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libparquet-15.0.2-h7ec3a38_1_cpu.conda
   hash:
-    md5: 32c92590859b2a8607dc656dec4157df
-    sha256: 5e9c21a679d30569c4552154aac3dc0e89cc6f22dfdbd48974ad847daa550f50
+    md5: ed2a8225a571cecb51eb0a3e68edc8dc
+    sha256: 44b5242d76e63fff53deded142ebe762a05a1f6beb3392e267ba30688e3bea1f
   category: main
   optional: false
 - name: libpng
-  version: 1.6.42
+  version: 1.6.43
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.42-h2797004_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.43-h2797004_0.conda
   hash:
-    md5: d67729828dc6ff7ba44a61062ad79880
-    sha256: 1a0c3a4b7fd1e101cb37dd6d2f8b5ec93409c8cae422f04470fe39a01ef59024
+    md5: 009981dd9cfcaa4dbfa25ffaed86bcae
+    sha256: 502f6ff148ac2777cc55ae4ade01a8fc3543b4ffab25c4e0eaa15f94e90dd997
   category: main
   optional: false
 - name: libpng
-  version: 1.6.42
+  version: 1.6.43
   manager: conda
   platform: osx-64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.42-h92b6c6a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.43-h92b6c6a_0.conda
   hash:
-    md5: 7654da21e9d7ca6a8c87fbc77448588e
-    sha256: 57c816e3b8cd0aaca7b85e79c0cc2211789ce0729a581d006faf8daeebf51f8d
+    md5: 65dcddb15965c9de2c0365cb14910532
+    sha256: 13e646d24b5179e6b0a5ece4451a587d759f55d9a360b7015f8f96eff4524b8f
   category: main
   optional: false
 - name: libpng
-  version: 1.6.42
+  version: 1.6.43
   manager: conda
   platform: osx-arm64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.42-h091b4b1_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.43-h091b4b1_0.conda
   hash:
-    md5: 308b6746e691265c21cb013960c74ae6
-    sha256: 6df48b05868437377a0717b486d9f57396a45cb6e3a044453944c8e597b03370
+    md5: 77e684ca58d82cae9deebafb95b1a2b8
+    sha256: 66c4713b07408398f2221229a1c1d5df57d65dc0902258113f2d9ecac4772495
   category: main
   optional: false
 - name: libpng
-  version: 1.6.42
+  version: 1.6.43
   manager: conda
   platform: win-64
   dependencies:
@@ -9103,10 +7135,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.42-h19919ed_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.43-h19919ed_0.conda
   hash:
-    md5: 9d97d0e6a5d51a7fd03c3398bc752890
-    sha256: 92a7f54585bac3b5f90e89bb674be1bd2e66e281206ec056a125eec7e32bb85f
+    md5: 77e398acc32617a0384553aea29e866b
+    sha256: 6ad31bf262a114de5bbe0c6ba73b29ed25239d0f46f9d59700310d2ea0b3c142
   category: main
   optional: false
 - name: libpq
@@ -9117,10 +7149,10 @@ package:
     krb5: '>=1.21.2,<1.22.0a0'
     libgcc-ng: '>=12'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpq-16.2-h33b98f1_1.conda
   hash:
-    md5: fe0e297faf462ee579c95071a5211665
-    sha256: 352748b0499a22e2a8e103f071b8d9357e1fb710c0aec0f79895d3ba03dccb03
+    md5: 9e49ec2a61d02623b379dc332eb6889d
+    sha256: e03a8439b79e013840c44c957d37dbce10316888b2b5dc7dcfcfc0cfe3a3b128
   category: main
   optional: false
 - name: libpq
@@ -9130,10 +7162,10 @@ package:
   dependencies:
     krb5: '>=1.21.2,<1.22.0a0'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpq-16.2-ha925e61_1.conda
   hash:
-    md5: 8b81f4feaa3744271fcf2822ad1489f1
-    sha256: 537b3816ac66f12c56fc62a67d896703b68f7588a5d83ab98009731de82eb742
+    md5: a10ef466bbc68a8e74112a8e26028d66
+    sha256: bfb252cb14b88a75ba4af930c16dccae265dce0afdf5abde7de1718181aa2cea
   category: main
   optional: false
 - name: libpq
@@ -9143,10 +7175,10 @@ package:
   dependencies:
     krb5: '>=1.21.2,<1.22.0a0'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpq-16.2-h0f8b458_1.conda
   hash:
-    md5: fea5d30234a7158f4eaa915b5a6e0c9c
-    sha256: 0ad2265131a6d79fcfe8c5b7a04884f7377f981d18af775ebb71bc61b0c938b6
+    md5: e236a8e95b82a454e333f22418b9c879
+    sha256: 7a6a195d37f6fe2f2d608033755f6e9522c9a2b7b07e52529159105f635c6cae
   category: main
   optional: false
 - name: libpq
@@ -9159,127 +7191,126 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libpq-16.2-hdb24f17_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libpq-16.2-hdb24f17_1.conda
   hash:
-    md5: c2e66b1a4350b02557b9f63626cda4e5
-    sha256: ae4e89c6fb924fbf0ac82b3462fc003277466b186ad48bf7a422dced00f6efd2
+    md5: a347334764562545270c6acc4b852ccf
+    sha256: b217f10336ca02bcffd2adf474fecf4bc917d8fbd26ab027b96e0d05257e5537
   category: main
   optional: false
 - name: libprotobuf
-  version: 4.25.1
+  version: 4.25.3
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.1-hf27288f_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-4.25.3-h08a7969_0.conda
   hash:
-    md5: 78ad06185133494138cd5e922ed73ac7
-    sha256: 4f3f6db5fb502ae1392d3f8d66639154b8ba7bf5c0547be988ec9236a5a784b2
+    md5: 6945825cebd2aeb16af4c69d97c32c13
+    sha256: 70e0eef046033af2e8d21251a785563ad738ed5281c74e21c31c457780845dcd
   category: main
   optional: false
 - name: libprotobuf
-  version: 4.25.1
+  version: 4.25.3
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libabseil: '>=20230802.1,<20230803.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libcxx: '>=16'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.1-hc4f2305_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-4.25.3-h4e4d658_0.conda
   hash:
-    md5: e75c3761805ceb70bbc28b8109f67d85
-    sha256: 9f0eccde6aabded86225d60166c93544f138aa0fad7478e4811879dbd61bffbc
+    md5: 57b7ee4f1fd8573781cfdabaec4a7782
+    sha256: 3f126769fb5820387d436370ad48600e05d038a28689fdf9988b64e1059947a8
   category: main
   optional: false
 - name: libprotobuf
-  version: 4.25.1
+  version: 4.25.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libcxx: '>=16'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.1-h810fc01_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-4.25.3-hbfab5d5_0.conda
   hash:
-    md5: 3e1535cfcf9d0f8e1141e021248c721e
-    sha256: bdaff15489c9a64ae150ba9fba29c2f019c86c36fc2828aa6edfffdd32313830
+    md5: 5f70b2b945a9741cba7e6dfe735a02a7
+    sha256: d754519abc3ddbdedab2a38d0639170f5347c1573eef80c707f3a8dc5dff706a
   category: main
   optional: false
 - name: libprotobuf
-  version: 4.25.1
+  version: 4.25.3
   manager: conda
   platform: win-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.1-hb8276f3_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-4.25.3-h503648d_0.conda
   hash:
-    md5: 6fac1decbb9591b391c124dc7bc39905
-    sha256: 980d7736424a5750fbec3ca454fc5654096eb93fc4cc5f44598919ce3710b951
+    md5: 4da7de0ba35777742edf67bf7a1075df
+    sha256: 5d4c5592be3994657ebf47e52f26b734cc50b0ea9db007d920e2e31762aac216
   category: main
   optional: false
 - name: libre2-11
-  version: 2023.06.02
+  version: 2023.09.01
   manager: conda
   platform: linux-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.06.02-h7a70373_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2023.09.01-h5a48ba9_2.conda
   hash:
-    md5: c0e7eacd9694db3ef5ef2979a7deea70
-    sha256: 22b0b2169c80b65665ba0d6418bd5d3d4c7d89915ee0f9613403efe871c27db8
+    md5: 41c69fba59d495e8cf5ffda48a607e35
+    sha256: 3f3c65fe0e9e328b4c1ebc2b622727cef3e5b81b18228cfa6cf0955bc1ed8eff
   category: main
   optional: false
 - name: libre2-11
-  version: 2023.06.02
+  version: 2023.09.01
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.9'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcxx: '>=16.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.06.02-h4694dbf_0.conda
+    __osx: '>=10.13'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2023.09.01-h81f5012_2.conda
   hash:
-    md5: d7c00395eaf2446eec6ce0f34cfd5b78
-    sha256: 73acd1ade87762c3f1aacf2a7c6271dd1e1c972d46ea7c44d8781595bca9218e
+    md5: c5c36ec64e3c86504728c38b79011d08
+    sha256: 384b72a09bd4bb29c1aa085110b2f940dba431587ffb4e2c1a28f605887a1867
   category: main
   optional: false
 - name: libre2-11
-  version: 2023.06.02
+  version: 2023.09.01
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcxx: '>=16.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.06.02-h1753957_0.conda
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2023.09.01-h7b2c953_2.conda
   hash:
-    md5: 3b8652db4bf4e27fa1446526f7a78498
-    sha256: 8bafee8f8ef27f4cb0afffe5404dd1abfc5fd6eac1ee9b4847a756d440bd7aa7
+    md5: 0b7b2ced046d6b5fe6e9d46b1ee0324c
+    sha256: c8a0a6e7a627dc9c66ffb8858f8f6d499f67fd269b6636b25dc5169760610f05
   category: main
   optional: false
 - name: libre2-11
-  version: 2023.06.02
+  version: 2023.09.01
   manager: conda
   platform: win-64
   dependencies:
-    libabseil: '>=20230802.1,<20230803.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.06.02-h8c5ae5e_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2023.09.01-hf8d8778_2.conda
   hash:
-    md5: b5c24e75399edf13660f317f5d7d751e
-    sha256: c468915951532d0455737e08e5fb2a4e2a862c123a13feeaa12fe72671070e13
+    md5: cf54cb5077a60797d53a132d37af25fc
+    sha256: 04331dad30a076ebb24c683197a5feabf4fd9be0fa0e06f416767096f287f900
   category: main
   optional: false
 - name: librttopo
@@ -9481,54 +7512,54 @@ package:
   category: main
   optional: false
 - name: libsqlite
-  version: 3.45.1
+  version: 3.45.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.1-h2797004_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.45.2-h2797004_0.conda
   hash:
-    md5: fc4ccadfbf6d4784de88c41704792562
-    sha256: 1b379d1c652b25d0540251d422ef767472e768fd36b77261045e97f9ba6d3faa
+    md5: 866983a220e27a80cb75e85cb30466a1
+    sha256: 8cdbeb7902729e319510a82d7c642402981818702b58812af265ef55d1315473
   category: main
   optional: false
 - name: libsqlite
-  version: 3.45.1
+  version: 3.45.2
   manager: conda
   platform: osx-64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.1-h92b6c6a_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.45.2-h92b6c6a_0.conda
   hash:
-    md5: e451d14a5412cdc68be50493df251f55
-    sha256: d65ce7093ecf5884b241a5ca8d26f80d21eaebf14ca67923b50c249f47a84cf9
+    md5: 086f56e13a96a6cfb1bf640505ae6b70
+    sha256: 320ec73a4e3dd377757a2595770b8137ec4583df4d7782472d76377cdbdc4543
   category: main
   optional: false
 - name: libsqlite
-  version: 3.45.1
+  version: 3.45.2
   manager: conda
   platform: osx-arm64
   dependencies:
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.1-h091b4b1_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.45.2-h091b4b1_0.conda
   hash:
-    md5: a153a40a253962373b5330eb9d182da9
-    sha256: 64befc456a38907d1334fb58eb604a96625d3a23a2f34fbd203e0b307a4a141e
+    md5: 9d07427ee5bd9afd1e11ce14368a48d6
+    sha256: 7c234320a1a2132b9cc972aaa06bb215bb220a5b1addb0bed7a5a321c805920e
   category: main
   optional: false
 - name: libsqlite
-  version: 3.45.1
+  version: 3.45.2
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.1-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libsqlite-3.45.2-hcfcfb64_0.conda
   hash:
-    md5: c583c1d6999b7aa148eff3089e13c44b
-    sha256: e1010f4ac7b056d85d91e6cb6137ef118f920eba88059261689e543780b230df
+    md5: f95359f8dc5abf7da7776ece9ef10bc5
+    sha256: 4bb24b986550275a6d02835150d943c4c675808d05c0efc5c2a22154d007a69f
   category: main
   optional: false
 - name: libssh2
@@ -9667,7 +7698,7 @@ package:
   platform: linux-64
   dependencies:
     lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.19,<1.20.0a0'
+    libdeflate: '>=1.20,<1.21.0a0'
     libgcc-ng: '>=12'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libstdcxx-ng: '>=12'
@@ -9675,10 +7706,10 @@ package:
     libzlib: '>=1.2.13,<1.3.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-ha9c0a0a_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.6.0-h1dd3fc0_3.conda
   hash:
-    md5: 55ed21669b2015f77c180feb1dd41930
-    sha256: 45158f5fbee7ee3e257e6b9f51b9f1c919ed5518a94a9973fe7fa4764330473e
+    md5: 66f03896ffbe1a110ffda05c7a856504
+    sha256: fc3b210f9584a92793c07396cb93e72265ff3f1fa7ca629128bf0a50d5cb15e4
   category: main
   optional: false
 - name: libtiff
@@ -9687,17 +7718,17 @@ package:
   platform: osx-64
   dependencies:
     lerc: '>=4.0.0,<5.0a0'
-    libcxx: '>=15.0.7'
-    libdeflate: '>=1.19,<1.20.0a0'
+    libcxx: '>=16'
+    libdeflate: '>=1.20,<1.21.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libwebp-base: '>=1.3.2,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h684deea_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libtiff-4.6.0-h129831d_3.conda
   hash:
-    md5: 2ca10a325063e000ad6d2a5900061e0d
-    sha256: 1ef5bd7295f4316b111f70ad21356fb9f0de50b85a341cac9e3a61ac6487fdf1
+    md5: 568593071d2e6cea7b5fc1f75bfa10ca
+    sha256: f9b35c5ec1aea9a2cc20e9275a0bb8f056482faa8c5a62feb243ed780755ea30
   category: main
   optional: false
 - name: libtiff
@@ -9706,17 +7737,17 @@ package:
   platform: osx-arm64
   dependencies:
     lerc: '>=4.0.0,<5.0a0'
-    libcxx: '>=15.0.7'
-    libdeflate: '>=1.19,<1.20.0a0'
+    libcxx: '>=16'
+    libdeflate: '>=1.20,<1.21.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libwebp-base: '>=1.3.2,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-ha8a6c65_2.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libtiff-4.6.0-h07db509_3.conda
   hash:
-    md5: 596d6d949bab9a75a492d451f521f457
-    sha256: b18ef36eb90f190db22c56ae5a080bccc16669c8f5b795a6211d7b0c00c18ff7
+    md5: 28c9f8c6dd75666dfb296aea06c49cb8
+    sha256: 6df3e129682f6dc43826e5028e1807624b2a7634c4becbb50e56be9f77167f25
   category: main
   optional: false
 - name: libtiff
@@ -9725,7 +7756,7 @@ package:
   platform: win-64
   dependencies:
     lerc: '>=4.0.0,<5.0a0'
-    libdeflate: '>=1.19,<1.20.0a0'
+    libdeflate: '>=1.20,<1.21.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     ucrt: '>=10.0.20348.0'
@@ -9733,10 +7764,10 @@ package:
     vc14_runtime: '>=14.29.30139'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-h6e2ebb7_2.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libtiff-4.6.0-hddb2be6_3.conda
   hash:
-    md5: 08d653b74ee2dec0131ad4259ffbb126
-    sha256: f7b50b71840a5d8edd74a8bccf0c173ca2599bd136e366c35722272b4afa0500
+    md5: 6d1828c9039929e2f185c5fa9d133018
+    sha256: 2e04844865cfe0286d70482c129f159542b325f4e45774aaff5fbe5027b30b0a
   category: main
   optional: false
 - name: libutf8proc
@@ -9919,7 +7950,7 @@ package:
   category: main
   optional: false
 - name: libxml2
-  version: 2.12.5
+  version: 2.12.6
   manager: conda
   platform: linux-64
   dependencies:
@@ -9928,14 +7959,14 @@ package:
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.5-h232c23b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.12.6-h232c23b_1.conda
   hash:
-    md5: c442ebfda7a475f5e78f1c8e45f1e919
-    sha256: db9bf97e9e367985204331b58a059ebd5a4e0cb9e1c8754e9ecb23046b7b7bc1
+    md5: 6853448e9ca1cfd5f15382afd2a6d123
+    sha256: c0bd693bb1a7e5aba388a0c79be16ff92e2411e03aaa920f94b4b33bf099e254
   category: main
   optional: false
 - name: libxml2
-  version: 2.12.5
+  version: 2.12.6
   manager: conda
   platform: osx-64
   dependencies:
@@ -9943,14 +7974,14 @@ package:
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.5-hc0ae0f7_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.12.6-hc0ae0f7_1.conda
   hash:
-    md5: abe27e7ab68b95e8d0e41cd5018ec8ae
-    sha256: a84f355dcf9039ae54e21bf8833c16200f848fd333a5e68c143e142cc55dc07d
+    md5: bd85e0ca9e1ffaadc3b56079fd956035
+    sha256: 07a5dc7316d4c1ff3d924df6a76e6a13380d702fa5b3b1889e56d0672e5b8201
   category: main
   optional: false
 - name: libxml2
-  version: 2.12.5
+  version: 2.12.6
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -9958,14 +7989,14 @@ package:
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     xz: '>=5.2.6,<6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.5-h0d0cfa8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.12.6-h0d0cfa8_1.conda
   hash:
-    md5: 6aef67f18bef799926bc05948a1239e3
-    sha256: 34daea04dc08af703effe424527505789f8a50fa71b447c7cac6f0d36a02cce3
+    md5: c08526c957192192e1e7b4f622761144
+    sha256: f18775ca8494ead5451d4acfc53fa7ebf7a8b5ed04c43bcc50fab847c9780cb3
   category: main
   optional: false
 - name: libxml2
-  version: 2.12.5
+  version: 2.12.6
   manager: conda
   platform: win-64
   dependencies:
@@ -9974,10 +8005,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.5-hc3477c8_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/libxml2-2.12.6-hc3477c8_1.conda
   hash:
-    md5: d8c3c1c8242db352f38cd1dc0bf44f77
-    sha256: 15696b049911b3ea5d37672408e500fb27e375d865f8cceac9cb02f9349e6804
+    md5: eb9f59dd51f50f5aa369813fa63ba569
+    sha256: 1846c1318a5987e7315ca3648b55b38e5cfd9853370803a0f5159bc0071609c1
   category: main
   optional: false
 - name: libxslt
@@ -10141,25 +8172,25 @@ package:
   category: main
   optional: false
 - name: llvm-openmp
-  version: 17.0.6
+  version: 18.1.2
   manager: conda
   platform: osx-64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-17.0.6-hb6ac08f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-18.1.2-hb6ac08f_0.conda
   hash:
-    md5: f260ab897df05f729fc3e65dbb0850ef
-    sha256: 9ea2f7018f335fdc55bc9b21a388eb94ea47a243d9cbf6ec3d8862d4df9fb49b
+    md5: e7f7e91cfabd8c7172c9ae405214dd68
+    sha256: dc40b678f5be2caf4e89ee3dc9037399d0bcd46543bc258dc46e1b92d241c6a6
   category: main
   optional: false
 - name: llvm-openmp
-  version: 17.0.6
+  version: 18.1.2
   manager: conda
   platform: osx-arm64
   dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-17.0.6-hcd81f8e_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-18.1.2-hcd81f8e_0.conda
   hash:
-    md5: 52019d2fa0eddbbc4e6dcd30fae0c0a4
-    sha256: 0c217326c5931c1416b82f98169b8a8a52139f6f5f299dbb2efa7b21f65f225a
+    md5: 34646dc152f3949a2f8a67136d406dce
+    sha256: 2ed8ae5a4c6122d542564a9bb9d4961ed7d2fb9581f0ea8bd81e3a83e614b110
   category: main
   optional: false
 - name: lxml
@@ -10418,8 +8449,8 @@ package:
   platform: osx-64
   dependencies:
     python: '>=3.9'
-    scikit-learn: '>=1.0'
     numpy: '>=1.23'
+    scikit-learn: '>=1.0'
     scipy: '>=1.8'
     networkx: '>=2.7'
     pandas: '>=1.4,!=1.5.0'
@@ -10435,8 +8466,8 @@ package:
   platform: osx-arm64
   dependencies:
     python: '>=3.9'
-    scikit-learn: '>=1.0'
     numpy: '>=1.23'
+    scikit-learn: '>=1.0'
     scipy: '>=1.8'
     networkx: '>=2.7'
     pandas: '>=1.4,!=1.5.0'
@@ -10452,8 +8483,8 @@ package:
   platform: win-64
   dependencies:
     python: '>=3.9'
-    scikit-learn: '>=1.0'
     numpy: '>=1.23'
+    scikit-learn: '>=1.0'
     scipy: '>=1.8'
     networkx: '>=2.7'
     pandas: '>=1.4,!=1.5.0'
@@ -10520,7 +8551,7 @@ package:
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.8.2
+  version: 3.8.3
   manager: conda
   platform: linux-64
   dependencies:
@@ -10532,7 +8563,7 @@ package:
     kiwisolver: '>=1.3.1'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    numpy: '>=1.26.0,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
@@ -10540,66 +8571,65 @@ package:
     python-dateutil: '>=2.7'
     python_abi: 3.12.*
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.2-py312he5832f3_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.8.3-py312he5832f3_0.conda
   hash:
-    md5: 1bf345f8df6896b5a8016f16188946ba
-    sha256: e635bc4fbdf1d08900b58e7bcbe58e34f9e8e56edc1423fa0487a2b407abcdf3
+    md5: 3b0545901b09b1376b9c0e0ec72409de
+    sha256: d6e01e76397a750db8de24591411fa9daa057948b327966bf2cc0c9fc03f1451
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.8.2
+  version: 3.8.3
   manager: conda
   platform: osx-64
   dependencies:
-    __osx: '>=10.9'
+    __osx: '>=10.12'
     certifi: '>=2020.06.20'
     contourpy: '>=1.0.1'
     cycler: '>=0.10'
     fonttools: '>=4.22.0'
     freetype: '>=2.12.1,<3.0a0'
     kiwisolver: '>=1.3.1'
-    libcxx: '>=16.0.6'
-    numpy: '>=1.26.0,<2.0a0'
+    libcxx: '>=16'
+    numpy: '>=1.26.4,<2.0a0'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
     python: '>=3.12,<3.13.0a0'
     python-dateutil: '>=2.7'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.2-py312h302682c_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/matplotlib-base-3.8.3-py312h1fe5000_0.conda
   hash:
-    md5: 6a3b7c29d663a9cda13afb8f2638cc46
-    sha256: 4c696c3ef44c621cfda2848a0ebd8fba16b87829f72dc59b312e391375b80552
+    md5: 5f65fc4ce880d4c795e217d563a114ec
+    sha256: 1b86adb0729b816b9cfdd4a681f056edd4a1092ae3b2e54efb1514fc0b77416e
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.8.2
+  version: 3.8.3
   manager: conda
   platform: osx-arm64
   dependencies:
-    __osx: '>=10.9'
     certifi: '>=2020.06.20'
     contourpy: '>=1.0.1'
     cycler: '>=0.10'
     fonttools: '>=4.22.0'
     freetype: '>=2.12.1,<3.0a0'
     kiwisolver: '>=1.3.1'
-    libcxx: '>=16.0.6'
-    numpy: '>=1.26.0,<2.0a0'
+    libcxx: '>=16'
+    numpy: '>=1.26.4,<2.0a0'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
     python: '>=3.12,<3.13.0a0'
     python-dateutil: '>=2.7'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.2-py312hba9b818_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.8.3-py312ha6faf65_0.conda
   hash:
-    md5: 1f91c58bfc318e787bf75b8812f36ac1
-    sha256: 4bc2d68ed1a4a5fba56f82d54a60e76d3efbb59e11db5ed32fce58e2662fa20a
+    md5: b5438a4d66b4bb7914027f3e1c34fd9e
+    sha256: 0a30852a2076b17359348510b3f827da986e4d3e89c41f48ce6f6f0c8b5acbc3
   category: main
   optional: false
 - name: matplotlib-base
-  version: 3.8.2
+  version: 3.8.3
   manager: conda
   platform: win-64
   dependencies:
@@ -10609,7 +8639,7 @@ package:
     fonttools: '>=4.22.0'
     freetype: '>=2.12.1,<3.0a0'
     kiwisolver: '>=1.3.1'
-    numpy: '>=1.26.0,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     packaging: '>=20.0'
     pillow: '>=8'
     pyparsing: '>=2.3.1'
@@ -10619,14 +8649,14 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.2-py312h26ecaf7_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/matplotlib-base-3.8.3-py312h26ecaf7_0.conda
   hash:
-    md5: d911e61e5c0b3db91f4e46c64874461f
-    sha256: 997faaf5c50cd544f2eb65ae461189e078bc3d5ff1df008ee69fad46f4215f84
+    md5: 61dd1bddda8329454b5e1428646b5fe2
+    sha256: 70a548c7cf8d61d055a5daf5dce3b95e4d0ad698d35f932e1f39c0462eda2898
   category: main
   optional: false
 - name: minizip
-  version: 4.0.4
+  version: 4.0.5
   manager: conda
   platform: linux-64
   dependencies:
@@ -10635,53 +8665,53 @@ package:
     libiconv: '>=1.17,<2.0a0'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.4-h0ab5242_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.5-h0ab5242_0.conda
   hash:
-    md5: 813bc75d9c33ddd9c9d5b8d9c560e152
-    sha256: e25d24c4841aa85ed2153f826ae58e56ae4d12704fd9e52005a3d7edfeb3b95a
+    md5: 557396140c71eba588e96d597e0c61aa
+    sha256: 1a56549751f4c4a7998e0a8bcff367c3992cb832c0b211d775cfd644e1ef5e6b
   category: main
   optional: false
 - name: minizip
-  version: 4.0.4
+  version: 4.0.5
   manager: conda
   platform: osx-64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
-    libcxx: '>=15'
+    libcxx: '>=16'
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.4-h37d7099_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.0.5-h37d7099_0.conda
   hash:
-    md5: 36eb00b2cad8e12ee18683dbd15aeba6
-    sha256: c0be39fda07d913da8dbedc15306a1452780890822a8c04dcc8f46b533ca2908
+    md5: 2203b2e83c20305b3d669556c345c8e9
+    sha256: 426f4db1d56cdefa478a5ece35ed7624860548ace87d6ad927c4c9c6a7a20fec
   category: main
   optional: false
 - name: minizip
-  version: 4.0.4
+  version: 4.0.5
   manager: conda
   platform: osx-arm64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
-    libcxx: '>=15'
+    libcxx: '>=16'
     libiconv: '>=1.17,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.4-hc35e051_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.5-hc35e051_0.conda
   hash:
-    md5: 293ad87f065d0e1dc011ccafeb1bb0be
-    sha256: 0fbf65095148cfe9dab8b32b533b3d2752a66bbf459816345773ed73844a448b
+    md5: 3698392e5f0823e563c306dde1d3a800
+    sha256: 7ad93499e224d49c4f342afb85e24681fa3ef8405e2b1e0a4cb549e90eb8486d
   category: main
   optional: false
 - name: minizip
-  version: 4.0.4
+  version: 4.0.5
   manager: conda
   platform: win-64
   dependencies:
@@ -10692,10 +8722,10 @@ package:
     vc14_runtime: '>=14.29.30139'
     xz: '>=5.2.6,<6.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.4-h5bed578_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/minizip-4.0.5-h5bed578_0.conda
   hash:
-    md5: 26363ae28ac1928dcf846b4d68d5f29f
-    sha256: d9073fe4159263314b25f436b99ee0ebedad12fbf518937761089a5ff17259f5
+    md5: acd216ec6d40c7e05991dccc4f9165f2
+    sha256: 3b77d2f3e71df522e88e1ec4e30742257523ff3e42a4ae0d6c9c7605b4aa6e54
   category: main
   optional: false
 - name: mkl
@@ -10771,39 +8801,37 @@ package:
   category: main
   optional: false
 - name: ncurses
-  version: '6.4'
+  version: 6.4.20240210
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4-h59595ed_2.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.4.20240210-h59595ed_0.conda
   hash:
-    md5: 7dbaa197d7ba6032caf7ae7f32c1efa0
-    sha256: 91cc03f14caf96243cead96c76fe91ab5925a695d892e83285461fb927dece5e
+    md5: 97da8860a0da5413c7c98a3b3838a645
+    sha256: aa0f005b6727aac6507317ed490f0904430584fa8ca722657e7f0fb94741de81
   category: main
   optional: false
 - name: ncurses
-  version: '6.4'
+  version: 6.4.20240210
   manager: conda
   platform: osx-64
-  dependencies:
-    __osx: '>=10.9'
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4-h93d8f39_2.conda
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.4.20240210-h73e2aa4_0.conda
   hash:
-    md5: e58f366bd4d767e9ab97ab8b272e7670
-    sha256: ea0fca66bbb52a1ef0687d466518fe120b5f279684effd6fd336a7b0dddc423a
+    md5: 50f28c512e9ad78589e3eab34833f762
+    sha256: 50b72acf08acbc4e5332807653e2ca6b26d4326e8af16fad1fd3f2ce9ea55503
   category: main
   optional: false
 - name: ncurses
-  version: '6.4'
+  version: 6.4.20240210
   manager: conda
   platform: osx-arm64
-  dependencies:
-    __osx: '>=10.9'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4-h463b476_2.conda
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.4.20240210-h078ce10_0.conda
   hash:
-    md5: 52b6f254a7b9663e854f44b6570ed982
-    sha256: f6890634f815e8408d08f36503353f8dfd7b055e4c3b9ea2ee52180255cf4b0a
+    md5: 616ae8691e6608527d0071e6766dcb81
+    sha256: 06f0905791575e2cd3aa961493c56e490b3d82ad9eb49f1c332bd338b0216911
   category: main
   optional: false
 - name: networkx
@@ -10852,126 +8880,6 @@ package:
   hash:
     md5: 425fce3b531bed6ec3c74fab3e5f0a1c
     sha256: 7629aa4f9f8cdff45ea7a4701fe58dccce5bf2faa01c26eb44cbb27b7e15ca9d
-  category: main
-  optional: false
-- name: notebook
-  version: 7.1.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab: '>=4.1.1,<4.2.0'
-    jupyterlab_server: '>=2.22.1,<3'
-    notebook-shim: '>=0.2,<0.3'
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2c2661f5605923fca5bf875a98a9b6a6
-    sha256: 426ae293064364aeb2a77612ddb7a6bb6ebed60a67a522fef18172ececedddde
-  category: main
-  optional: false
-- name: notebook
-  version: 7.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab_server: '>=2.22.1,<3'
-    notebook-shim: '>=0.2,<0.3'
-    jupyterlab: '>=4.1.1,<4.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2c2661f5605923fca5bf875a98a9b6a6
-    sha256: 426ae293064364aeb2a77612ddb7a6bb6ebed60a67a522fef18172ececedddde
-  category: main
-  optional: false
-- name: notebook
-  version: 7.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab_server: '>=2.22.1,<3'
-    notebook-shim: '>=0.2,<0.3'
-    jupyterlab: '>=4.1.1,<4.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2c2661f5605923fca5bf875a98a9b6a6
-    sha256: 426ae293064364aeb2a77612ddb7a6bb6ebed60a67a522fef18172ececedddde
-  category: main
-  optional: false
-- name: notebook
-  version: 7.1.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    tornado: '>=6.2.0'
-    jupyter_server: '>=2.4.0,<3'
-    jupyterlab_server: '>=2.22.1,<3'
-    notebook-shim: '>=0.2,<0.3'
-    jupyterlab: '>=4.1.1,<4.2.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-7.1.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 2c2661f5605923fca5bf875a98a9b6a6
-    sha256: 426ae293064364aeb2a77612ddb7a6bb6ebed60a67a522fef18172ececedddde
-  category: main
-  optional: false
-- name: notebook-shim
-  version: 0.2.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    jupyter_server: '>=1.8,<3'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67e0fe74c156267d9159e9133df7fd37
-    sha256: f028d7ad1f2175cde307db08b60d07e371b9d6f035cfae6c81ea94b4c408c538
-  category: main
-  optional: false
-- name: notebook-shim
-  version: 0.2.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-    jupyter_server: '>=1.8,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67e0fe74c156267d9159e9133df7fd37
-    sha256: f028d7ad1f2175cde307db08b60d07e371b9d6f035cfae6c81ea94b4c408c538
-  category: main
-  optional: false
-- name: notebook-shim
-  version: 0.2.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    jupyter_server: '>=1.8,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67e0fe74c156267d9159e9133df7fd37
-    sha256: f028d7ad1f2175cde307db08b60d07e371b9d6f035cfae6c81ea94b4c408c538
-  category: main
-  optional: false
-- name: notebook-shim
-  version: 0.2.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-    jupyter_server: '>=1.8,<3'
-  url: https://conda.anaconda.org/conda-forge/noarch/notebook-shim-0.2.3-pyhd8ed1ab_0.conda
-  hash:
-    md5: 67e0fe74c156267d9159e9133df7fd37
-    sha256: f028d7ad1f2175cde307db08b60d07e371b9d6f035cfae6c81ea94b4c408c538
   category: main
   optional: false
 - name: nspr
@@ -11012,50 +8920,50 @@ package:
   category: main
   optional: false
 - name: nss
-  version: '3.97'
+  version: '3.98'
   manager: conda
   platform: linux-64
   dependencies:
     __glibc: '>=2.17,<3.0.a0'
     libgcc-ng: '>=12'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.1,<4.0a0'
     libstdcxx-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
     nspr: '>=4.35,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.97-h1d7d5a4_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/nss-3.98-h1d7d5a4_0.conda
   hash:
-    md5: b916d71a3032416e3f9136090d814472
-    sha256: a1a62d415e5b5ddbd799ad6d92b2c4a4351fda00b54d96cac2ce7afa04b2d698
+    md5: 54b56c2fdf973656b748e0378900ec13
+    sha256: a9bc94d03df48014011cf6caaf447f2ef86a5edf7c70d70002ec4b59f5a4e198
   category: main
   optional: false
 - name: nss
-  version: '3.97'
+  version: '3.98'
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=15'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libcxx: '>=16'
+    libsqlite: '>=3.45.1,<4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     nspr: '>=4.35,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.97-ha05da47_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/nss-3.98-ha05da47_0.conda
   hash:
-    md5: 6408f35df2c8ba0642b13d32915a789b
-    sha256: fe26704cb733d412fafbeaf0cc4c402f9623757bc2241381d7480a22cdeb64e4
+    md5: 79d062716d8e1f77cf806c6fe0f4405c
+    sha256: 3d99dd976aeb8678e4ac5fcbd574e1de50cdc57b742e22855f294c8047d5c68e
   category: main
   optional: false
 - name: nss
-  version: '3.97'
+  version: '3.98'
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libcxx: '>=16'
+    libsqlite: '>=3.45.1,<4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     nspr: '>=4.35,<5.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.97-h5ce2875_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nss-3.98-h5ce2875_0.conda
   hash:
-    md5: 5d2d69c2cce2c58171648a1fd34d6732
-    sha256: 27786510a52aeb1115c31d8127fcc57fdec38bcef22882dd3bd05d04ca5c393d
+    md5: db0d8f4d11186e4cb3f1a3e0385ca075
+    sha256: eecb5718c43dd68cf8150b1e75c91518dae457348828361034639e9e2ea82c82
   category: main
   optional: false
 - name: numpy
@@ -11130,66 +9038,66 @@ package:
   category: main
   optional: false
 - name: openjpeg
-  version: 2.5.0
+  version: 2.5.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libpng: '>=1.6.39,<1.7.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
     libstdcxx-ng: '>=12'
     libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.0-h488ebb8_3.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjpeg-2.5.2-h488ebb8_0.conda
   hash:
-    md5: 128c25b7fe6a25286a48f3a6a9b5b6f3
-    sha256: 9fe91b67289267de68fda485975bb48f0605ac503414dc663b50d8b5f29bc82a
+    md5: 7f2e286780f072ed750df46dc2631138
+    sha256: 5600a0b82df042bd27d01e4e687187411561dfc11cc05143a08ce29b64bf2af2
   category: main
   optional: false
 - name: openjpeg
-  version: 2.5.0
+  version: 2.5.2
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=15.0.7'
-    libpng: '>=1.6.39,<1.7.0a0'
+    libcxx: '>=16'
+    libpng: '>=1.6.43,<1.7.0a0'
     libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.0-ha4da562_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.2-h7310d3a_0.conda
   hash:
-    md5: 40a36f8e9a6fdf6a78c6428ee6c44188
-    sha256: fdccd9668b85bf6e798b628bceed5ff764e1114cfc4e6a4dee551cafbe549e74
+    md5: 05a14cc9d725dd74995927968d6547e3
+    sha256: dc9c405119b9b54f8ca5984da27ba498bd848ab4f0f580da6f293009ca5adc13
   category: main
   optional: false
 - name: openjpeg
-  version: 2.5.0
+  version: 2.5.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15.0.7'
-    libpng: '>=1.6.39,<1.7.0a0'
+    libcxx: '>=16'
+    libpng: '>=1.6.43,<1.7.0a0'
     libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.0-h4c1507b_3.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjpeg-2.5.2-h9f1df11_0.conda
   hash:
-    md5: 4127dd217a010d9c6cbefdaae07d9f19
-    sha256: a6998c0da4643a84dc7c0b3a9e5137db258619ea922317bb7d9ae64f54b4a9ed
+    md5: 5029846003f0bc14414b9128a1f7c84b
+    sha256: 472d6eaffc1996e6af35ec8e91c967f472a536a470079bfa56383cc0dbf4d463
   category: main
   optional: false
 - name: openjpeg
-  version: 2.5.0
+  version: 2.5.2
   manager: conda
   platform: win-64
   dependencies:
-    libpng: '>=1.6.39,<1.7.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
     libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.0-h3d672ee_3.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.2-h3d672ee_0.conda
   hash:
-    md5: 45a9628a04efb6fc326fff0a8f47b799
-    sha256: c0f64d9642f0287f17cd9b6f1633d97a91efd66a0cb9b0414c540b247684985d
+    md5: 7e7099ad94ac3b599808950cec30ad4e
+    sha256: dda71cbe094234ab208f3552dec1f4ca6f2e614175d010808d6cb66ecf0bc753
   category: main
   optional: false
 - name: openssl
@@ -11199,10 +9107,10 @@ package:
   dependencies:
     ca-certificates: ''
     libgcc-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.2.1-hd590300_1.conda
   hash:
-    md5: 51a753e64a3027bd7e23a189b1f6e91e
-    sha256: c02c12bdb898daacf7eb3d09859f93ea8f285fd1a6132ff6ff0493ab52c7fe57
+    md5: 9d731343cff6ee2e5a25c4a091bf8e2a
+    sha256: 2c689444ed19a603be457284cf2115ee728a3fafb7527326e96054dee7cdc1a7
   category: main
   optional: false
 - name: openssl
@@ -11211,10 +9119,10 @@ package:
   platform: osx-64
   dependencies:
     ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.2.1-hd75f5a5_1.conda
   hash:
-    md5: 3033be9a59fd744172b03971b9ccd081
-    sha256: 20c1b1a34a1831c24d37ed1500ca07300171184af0c66598f3c5ca901634d713
+    md5: 570a6f04802df580be529f3a72d2bbf7
+    sha256: 7ae0ac6a1673584a8a380c2ff3d46eca48ed53bc7174c0d4eaa0dd2f247a0984
   category: main
   optional: false
 - name: openssl
@@ -11223,10 +9131,10 @@ package:
   platform: osx-arm64
   dependencies:
     ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.2.1-h0d3ecfb_1.conda
   hash:
-    md5: 421cc6e8715447b73c2c57dcf78cb9d2
-    sha256: 13663fcd4abc8681b31ccbad39800fee2127cb6159b51a989ed48a816af36cf5
+    md5: eb580fb888d93d5d550c557323ac5cee
+    sha256: 519dc941d7ab0ebf31a2878d85c2f444450e7c5f6f41c4d07252c6bb3417b78b
   category: main
   optional: false
 - name: openssl
@@ -11238,71 +9146,69 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/openssl-3.2.1-hcfcfb64_1.conda
   hash:
-    md5: 158df8eead8092cf0e27167c8761a8dd
-    sha256: 1df1c43136f863d5e9ba20b703001caf9a4d0ea56bdc3eeb948c977e3d4f91d3
+    md5: 958e0418e93e50c575bff70fbcaa12d8
+    sha256: 61ce4e11c3c26ed4e4d9b7e7e2483121a1741ad0f9c8db0a91a28b6e05182ce6
   category: main
   optional: false
 - name: orc
-  version: 1.9.2
+  version: 2.0.0
   manager: conda
   platform: linux-64
   dependencies:
-    libgcc-ng: '>=12'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
-    libstdcxx-ng: '>=12'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     snappy: '>=1.1.10,<2.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/orc-1.9.2-h7829240_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/orc-2.0.0-h1e5e2c1_0.conda
   hash:
-    md5: 306ffb76ce3cdfc539d29fa5b8dd716c
-    sha256: 051d28565da5899b46897f4811d9ee4d2ff1d9c618c092eef73bc13badb704c0
+    md5: 53e8f030579d34e1a36a735d527c021f
+    sha256: ed8cfe1f35e8ef703e540e7731e77fade1410bba406e17727a10dee08c37d5b4
   category: main
   optional: false
 - name: orc
-  version: 1.9.2
+  version: 2.0.0
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    libcxx: '>=15'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
+    libcxx: '>=16'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     snappy: '>=1.1.10,<2.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/orc-1.9.2-ha277160_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/orc-2.0.0-h6c6cd50_0.conda
   hash:
-    md5: 5abf98a78ed66f1164e56e7cb852660e
-    sha256: a4ad062d21bd4dcca20048cf22eff203f34b28514b19d114b2ac547510c14f85
+    md5: 5ce58b9a5679fe6640d6d68228099ce9
+    sha256: 0c198b6a8de238d53002e7c03e4b1e94e769cf388adac2717fdaadfee9381a14
   category: main
   optional: false
 - name: orc
-  version: 1.9.2
+  version: 2.0.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15'
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
+    libcxx: '>=16'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     snappy: '>=1.1.10,<2.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-1.9.2-hb41d57e_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/orc-2.0.0-h3d3088e_0.conda
   hash:
-    md5: 2b7e8bb8c22c8e73bd8307d0e4fb3d15
-    sha256: 5930ff00fdae4b0e640023ba8c72ad77dc9018c63c36326f91efae2bf22b459f
+    md5: a8e452c3f2b6fecfd86e8f2b72450a9b
+    sha256: 6a1f553e2ea3d2df3c465b02c7ece5c001cc2d3afb1fe7e2678a7ff7a5a14168
   category: main
   optional: false
 - name: orc
-  version: 1.9.2
+  version: 2.0.0
   manager: conda
   platform: win-64
   dependencies:
-    libprotobuf: '>=4.25.1,<4.25.2.0a0'
+    libprotobuf: '>=4.25.3,<4.25.4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
     snappy: '>=1.1.10,<2.0a0'
@@ -11310,121 +9216,121 @@ package:
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/orc-1.9.2-hf6f83f4_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/orc-2.0.0-heb0c069_0.conda
   hash:
-    md5: 07b32e66750eed8e7a15ff0ee1187df8
-    sha256: d66c24024b652b6509a3ba5bc25d8b9cb6f6d46cd79ebacf7def1d758831d4b1
+    md5: 2733034196c084cdc07e0facfea995ea
+    sha256: 5a9c0904f38e5c2e1d1494bd192ff98fca13ca07ed1590497b16a801bef497a0
   category: main
   optional: false
 - name: packaging
-  version: '23.2'
+  version: '24.0'
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+    md5: 248f521b64ce055e7feae3105e7abeb8
+    sha256: a390182d74c31dfd713c16db888c92c277feeb6d1fe96ff9d9c105f9564be48a
   category: main
   optional: false
 - name: packaging
-  version: '23.2'
+  version: '24.0'
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+    md5: 248f521b64ce055e7feae3105e7abeb8
+    sha256: a390182d74c31dfd713c16db888c92c277feeb6d1fe96ff9d9c105f9564be48a
   category: main
   optional: false
 - name: packaging
-  version: '23.2'
+  version: '24.0'
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+    md5: 248f521b64ce055e7feae3105e7abeb8
+    sha256: a390182d74c31dfd713c16db888c92c277feeb6d1fe96ff9d9c105f9564be48a
   category: main
   optional: false
 - name: packaging
-  version: '23.2'
+  version: '24.0'
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/packaging-23.2-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 79002079284aa895f883c6b7f3f88fd6
-    sha256: 69b3ace6cca2dab9047b2c24926077d81d236bef45329d264b394001e3c3e52f
+    md5: 248f521b64ce055e7feae3105e7abeb8
+    sha256: a390182d74c31dfd713c16db888c92c277feeb6d1fe96ff9d9c105f9564be48a
   category: main
   optional: false
 - name: pandas
-  version: 2.2.0
+  version: 2.2.1
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    numpy: '>=1.26.3,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python-dateutil: '>=2.8.1'
     python-tzdata: '>=2022a'
     python_abi: 3.12.*
     pytz: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.0-py312hfb8ada1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pandas-2.2.1-py312hfb8ada1_0.conda
   hash:
-    md5: 07dc8151dda37002f69a95cec87f0526
-    sha256: 4f0fdce898e94d5c5b7970ac8c39497949af86e5985c9094f325f696bc2cea9a
+    md5: e8fcd9179004edd4fb1bcd888d0aeb47
+    sha256: 148e4f38f2ed6525171f3c779e970a999f5bc78ddb9a9d300847d73bbd742c33
   category: main
   optional: false
 - name: pandas
-  version: 2.2.0
+  version: 2.2.1
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=15'
-    numpy: '>=1.26.3,<2.0a0'
+    libcxx: '>=16'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python-dateutil: '>=2.8.1'
     python-tzdata: '>=2022a'
     python_abi: 3.12.*
     pytz: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.0-py312h83c8a23_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pandas-2.2.1-py312h83c8a23_0.conda
   hash:
-    md5: b5a2e09aa631f35983fe291fcc340f6e
-    sha256: 72b58d623b6d58ce55bed5d81244caa60df7a739090fac380875091525fd1e7d
+    md5: c562e07382cdc3194c21b8eca06460ff
+    sha256: ea83713caaa07c33c9530bc7469bec0b73fdd24ffee286cc6f3d26b1aa89f397
   category: main
   optional: false
 - name: pandas
-  version: 2.2.0
+  version: 2.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15'
-    numpy: '>=1.26.3,<2.0a0'
+    libcxx: '>=16'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python-dateutil: '>=2.8.1'
     python-tzdata: '>=2022a'
     python_abi: 3.12.*
     pytz: '>=2020.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.0-py312h88edd18_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-2.2.1-py312h88edd18_0.conda
   hash:
-    md5: 118b50e4e7c92c1554cdd5b14816a122
-    sha256: 96718cc34d54c72c380c75387ecf5ef8838f56acc9fa6fac882a914afb073a6f
+    md5: 0a9617836a53de8eba750a84163d75b2
+    sha256: db38529f8d8fe7764b0fb89f1f561a079cfc95921646b26e44762fd81b4f1e13
   category: main
   optional: false
 - name: pandas
-  version: 2.2.0
+  version: 2.2.1
   manager: conda
   platform: win-64
   dependencies:
-    numpy: '>=1.26.3,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python-dateutil: '>=2.8.1'
     python-tzdata: '>=2022a'
@@ -11433,194 +9339,54 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.0-py312h2ab9e98_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pandas-2.2.1-py312h2ab9e98_0.conda
   hash:
-    md5: 5cf40988e95c84634230633bc28b8cc7
-    sha256: 94a41280895fc7a30f44ab032e5170f2e6aafe8ba82f2f4614acb88dd2a8f562
-  category: main
-  optional: false
-- name: pandoc
-  version: 3.1.11.1
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/pandoc-3.1.11.1-ha770c72_0.conda
-  hash:
-    md5: 0e2f14aff42adf4675bcd5335d644a5f
-    sha256: 30b1318dbf7a89d4b2f66a9b10c8799376a32506043a510e1d27ba286c564633
-  category: main
-  optional: false
-- name: pandoc
-  version: 3.1.11.1
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/pandoc-3.1.11.1-h694c41f_0.conda
-  hash:
-    md5: 6cff44b16d1231fe9682c64d12ab66a5
-    sha256: 3adbae2ba5d78c45c9ec9d802b820c2e659129b7ba044cc76487ce33dbc800f2
-  category: main
-  optional: false
-- name: pandoc
-  version: 3.1.11.1
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pandoc-3.1.11.1-hce30654_0.conda
-  hash:
-    md5: bb4cbaefaa40290fc4bb09b224bc2ebb
-    sha256: 80044e15ee1ffeb52ab8b36270b5cb99b56027aabd4e2e7aa1814087ceb6317a
-  category: main
-  optional: false
-- name: pandoc
-  version: 3.1.11.1
-  manager: conda
-  platform: win-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/win-64/pandoc-3.1.11.1-h57928b3_0.conda
-  hash:
-    md5: 81747ed06ea58a00b41ea15bf6e1fe30
-    sha256: 84cbba7f556b173c84cb3aba6a43ff088dd4808d529a598e5fd124dca710bc1b
-  category: main
-  optional: false
-- name: pandocfilters
-  version: 1.5.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '!=3.0,!=3.1,!=3.2,!=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 457c2c8c08e54905d6954e79cb5b5db9
-    sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
-  category: main
-  optional: false
-- name: pandocfilters
-  version: 1.5.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '!=3.0,!=3.1,!=3.2,!=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 457c2c8c08e54905d6954e79cb5b5db9
-    sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
-  category: main
-  optional: false
-- name: pandocfilters
-  version: 1.5.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '!=3.0,!=3.1,!=3.2,!=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 457c2c8c08e54905d6954e79cb5b5db9
-    sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
-  category: main
-  optional: false
-- name: pandocfilters
-  version: 1.5.0
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '!=3.0,!=3.1,!=3.2,!=3.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pandocfilters-1.5.0-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 457c2c8c08e54905d6954e79cb5b5db9
-    sha256: 2bb9ba9857f4774b85900c2562f7e711d08dd48e2add9bee4e1612fbee27e16f
-  category: main
-  optional: false
-- name: parso
-  version: 0.8.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 17a565a0c3899244e938cdf417e7b094
-    sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
-  category: main
-  optional: false
-- name: parso
-  version: 0.8.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 17a565a0c3899244e938cdf417e7b094
-    sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
-  category: main
-  optional: false
-- name: parso
-  version: 0.8.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 17a565a0c3899244e938cdf417e7b094
-    sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
-  category: main
-  optional: false
-- name: parso
-  version: 0.8.3
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/parso-0.8.3-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: 17a565a0c3899244e938cdf417e7b094
-    sha256: 4e26d5daf5de0e31aa5e74ac56386a361b202433b83f024fdadbf07d4a244da4
+    md5: 864da9103c0201f4ee512910eee91ab0
+    sha256: 3031be90c1234ab3f8e60b548cecae2c0278c661b4e1dc7c6c0e15beb7f0fd23
   category: main
   optional: false
 - name: pcre2
-  version: '10.42'
+  version: '10.43'
   manager: conda
   platform: linux-64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
     libgcc-ng: '>=12'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.42-hcad00b1_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.43-hcad00b1_0.conda
   hash:
-    md5: 679c8961826aa4b50653bce17ee52abe
-    sha256: 3ca54ff0abcda964af7d4724d389ae20d931159ae1881cfe57ad4b0ab9e6a380
+    md5: 8292dea9e022d9610a11fce5e0896ed8
+    sha256: 766dd986a7ed6197676c14699000bba2625fd26c8a890fcb7a810e5cf56155bc
   category: main
   optional: false
 - name: pcre2
-  version: '10.42'
+  version: '10.43'
   manager: conda
   platform: osx-64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.42-h0ad2156_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.43-h0ad2156_0.conda
   hash:
-    md5: 41de8bab2d5e5cd6daaba1896e81d366
-    sha256: 689559d94b64914e503d2ced53b78afc19562ed1ccfb284040797a6d41bb564c
+    md5: 9c8651803886ce9d5983e107a0df4ea8
+    sha256: 226714bbf89d45bf7da4c7551e21b8a833f51d33379fe3dfbfe31b72832d4dba
   category: main
   optional: false
 - name: pcre2
-  version: '10.42'
+  version: '10.43'
   manager: conda
   platform: osx-arm64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.42-h26f9a81_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.43-h26f9a81_0.conda
   hash:
-    md5: 3e12888ecc8ee1ebee2eef9b7856357a
-    sha256: 0335a08349ecd8dce0b81699fcd61b58415e658fe953feb27316fbb994df0685
+    md5: 1ddc87f00014612830f3235b5ad6d821
+    sha256: 4bf7b5fa091f5e7ab0b78778458be1e81c1ffa182b63795734861934945a63a7
   category: main
   optional: false
 - name: pcre2
-  version: '10.42'
+  version: '10.43'
   manager: conda
   platform: win-64
   dependencies:
@@ -11629,66 +9395,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.42-h17e33f8_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.43-h17e33f8_0.conda
   hash:
-    md5: 59610c61da3af020289a806ec9c6a7fd
-    sha256: 25e33b148478de58842ccc018fbabb414665de59270476e92c951203d4485bb1
-  category: main
-  optional: false
-- name: pdfminer.six
-  version: '20231228'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    charset-normalizer: '>=2.0.0'
-    cryptography: '>=36.0.0'
-    python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/pdfminer.six-20231228-pyhd8ed1ab_0.conda
-  hash:
-    md5: e61f6b78673ea5e0273592cfc76eb16d
-    sha256: 3d57473e40c6fefca597eb394f1b25a6e2353e2597bae13137a70179ad4a3044
-  category: main
-  optional: false
-- name: pdfminer.six
-  version: '20231228'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.8'
-    cryptography: '>=36.0.0'
-    charset-normalizer: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pdfminer.six-20231228-pyhd8ed1ab_0.conda
-  hash:
-    md5: e61f6b78673ea5e0273592cfc76eb16d
-    sha256: 3d57473e40c6fefca597eb394f1b25a6e2353e2597bae13137a70179ad4a3044
-  category: main
-  optional: false
-- name: pdfminer.six
-  version: '20231228'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.8'
-    cryptography: '>=36.0.0'
-    charset-normalizer: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pdfminer.six-20231228-pyhd8ed1ab_0.conda
-  hash:
-    md5: e61f6b78673ea5e0273592cfc76eb16d
-    sha256: 3d57473e40c6fefca597eb394f1b25a6e2353e2597bae13137a70179ad4a3044
-  category: main
-  optional: false
-- name: pdfminer.six
-  version: '20231228'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.8'
-    cryptography: '>=36.0.0'
-    charset-normalizer: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pdfminer.six-20231228-pyhd8ed1ab_0.conda
-  hash:
-    md5: 422748adcaf5c23c8c0f7ea84e7469c4
-    sha256: 9009014de36efeb31d5d42a0fbf4704c59f9c7714a957b7aad66997a753aa90e
+    md5: d0485b8aa2cedb141a7bd27b4efa4c9c
+    sha256: 9a82c7d49c4771342b398661862975efb9c30e7af600b5d2e08a0bf416fda492
   category: main
   optional: false
 - name: pdfminer.six
@@ -11745,97 +9455,10 @@ package:
   hash:
     md5: e61f6b78673ea5e0273592cfc76eb16d
     sha256: 3d57473e40c6fefca597eb394f1b25a6e2353e2597bae13137a70179ad4a3044
-  category: main
-  optional: false
-- name: pexpect
-  version: 4.9.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    ptyprocess: '>=0.5'
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 629f3203c99b32e0988910c93e77f3b6
-    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
-  category: main
-  optional: false
-- name: pexpect
-  version: 4.9.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-    ptyprocess: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 629f3203c99b32e0988910c93e77f3b6
-    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
-  category: main
-  optional: false
-- name: pexpect
-  version: 4.9.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-    ptyprocess: '>=0.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/pexpect-4.9.0-pyhd8ed1ab_0.conda
-  hash:
-    md5: 629f3203c99b32e0988910c93e77f3b6
-    sha256: 90a09d134a4a43911b716d4d6eb9d169238aff2349056f7323d9db613812667e
-  category: main
-  optional: false
-- name: pickleshare
-  version: 0.7.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-  hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-  category: main
-  optional: false
-- name: pickleshare
-  version: 0.7.5
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-  hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-  category: main
-  optional: false
-- name: pickleshare
-  version: 0.7.5
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-  hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
-  category: main
-  optional: false
-- name: pickleshare
-  version: 0.7.5
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3'
-  url: https://conda.anaconda.org/conda-forge/noarch/pickleshare-0.7.5-py_1003.tar.bz2
-  hash:
-    md5: 415f0ebb6198cc2801c73438a9fb5761
-    sha256: a1ed1a094dd0d1b94a09ed85c283a0eb28943f2e6f22161fb45e128d35229738
   category: main
   optional: false
 - name: pillow
-  version: 10.2.0
+  version: 10.3.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -11847,18 +9470,18 @@ package:
     libwebp-base: '>=1.3.2,<2.0a0'
     libxcb: '>=1.15,<1.16.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.2.0-py312hf3581a9_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pillow-10.3.0-py312hdcec9eb_0.conda
   hash:
-    md5: f35cb852483290b40b5a47e117e80a1d
-    sha256: 27f589c316efae5b57b9fea207757574b7b455addf470929099c4bab93aaa1d2
+    md5: 425bb325f970e57a047ac57c4586489d
+    sha256: a7fdcc1e56b66d95622bad073cc8d347cc180988040419754abb2a4ed7b29471
   category: main
   optional: false
 - name: pillow
-  version: 10.2.0
+  version: 10.3.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -11869,18 +9492,18 @@ package:
     libwebp-base: '>=1.3.2,<2.0a0'
     libxcb: '>=1.15,<1.16.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.2.0-py312h0c70c2f_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pillow-10.3.0-py312h0c923fa_0.conda
   hash:
-    md5: 0cc3674239ad12c6836cb4174f106c92
-    sha256: ce465f778b7a0629cfb72aff8e7d6888c8c65971538d17824defeed8c5d05736
+    md5: 6f0591ae972e9b815739da3392fbb3c3
+    sha256: 3e33ce8ba364948eeeeb06da435059b1ed0e6cfb2b1195931b76e190ee671310
   category: main
   optional: false
 - name: pillow
-  version: 10.2.0
+  version: 10.3.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -11891,14 +9514,14 @@ package:
     libwebp-base: '>=1.3.2,<2.0a0'
     libxcb: '>=1.15,<1.16.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     tk: '>=8.6.13,<8.7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.2.0-py312hac22aec_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-10.3.0-py312h8a801b1_0.conda
   hash:
-    md5: 486a50718de90e091df0bef6e6af2c48
-    sha256: 83ebcca5ca6c63bd15a80806a0110d45431fed7c432234d3299202e00f28c0e4
+    md5: 1d42544faaed27dce36268912b8dfedf
+    sha256: 26bc04e81ae5fce70e4b72478dadea29d32b693eed17640be7721108a3c9af0d
   category: main
   optional: false
 - name: pillow
@@ -11996,41 +9619,41 @@ package:
   category: main
   optional: false
 - name: pixman
-  version: 0.43.2
+  version: 0.43.4
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.2-h73e2aa4_0.conda
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-64/pixman-0.43.4-h73e2aa4_0.conda
   hash:
-    md5: 26cf3be47886ded561d3d2cd8654893f
-    sha256: 26b16d9a6aed8f3d96a7dbad5d63b6ab1bcce13d77c050bcbaf7378bada2d225
+    md5: cb134c1e03fd32f4e6bea3f6de2614fd
+    sha256: 3ab44e12e566c67a6e9fd831f557ab195456aa996b8dd9af19787ca80caa5cd1
   category: main
   optional: false
 - name: pixman
-  version: 0.43.2
+  version: 0.43.4
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.2-hebf3989_0.conda
+    libcxx: '>=16'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pixman-0.43.4-hebf3989_0.conda
   hash:
-    md5: aaf3f4397959b8900c7c2f90304ccb29
-    sha256: dc3ec60e769f80c1d5124ba2788e3c9122443743989ad5f92addf416c7a4e58b
+    md5: 0308c68e711cd295aaa026a4f8c4b1e5
+    sha256: df0ba2710ccdea5c909b63635529797f6eb3635b6fb77ae9cb2f183d08818409
   category: main
   optional: false
 - name: pixman
-  version: 0.43.2
+  version: 0.43.4
   manager: conda
   platform: win-64
   dependencies:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.2-h63175ca_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pixman-0.43.4-h63175ca_0.conda
   hash:
-    md5: 1060b0e26af2192e80b1d04cae0b029f
-    sha256: 659db230ba8121395b23fa6fce5f16532f54e4e7397ff9e7c19d9c7e436d29f8
+    md5: b98135614135d5f458b75ab9ebb9558c
+    sha256: 51de4d7fb41597b06d60f1b82e269dafcb55e994e08fdcca8e4d6f7d42bedd07
   category: main
   optional: false
 - name: pluggy
@@ -12082,7 +9705,7 @@ package:
   category: main
   optional: false
 - name: poppler
-  version: 24.02.0
+  version: 24.03.0
   manager: conda
   platform: linux-64
   dependencies:
@@ -12093,25 +9716,25 @@ package:
     lcms2: '>=2.16,<3.0a0'
     libcurl: '>=8.5.0,<9.0a0'
     libgcc-ng: '>=12'
-    libglib: '>=2.78.3,<3.0a0'
+    libglib: '>=2.78.4,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
     libstdcxx-ng: '>=12'
     libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     nspr: '>=4.35,<5.0a0'
-    nss: '>=3.97,<4.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    nss: '>=3.98,<4.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     poppler-data: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.02.0-h590f24d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/poppler-24.03.0-h590f24d_0.conda
   hash:
-    md5: 7e715c1572de09d6106c5a31fa70ffca
-    sha256: 55bb2deb67c76bd9f5592bf9765cc879cf11e555c4f8879292cbd5544e88887e
+    md5: c688853df9dcfed47200d0e28e5dfe11
+    sha256: 0ea3e63ae3ba07bcae8cc541647c647c68aeec32dfbe3bbaeecc845833b27a6f
   category: main
   optional: false
 - name: poppler
-  version: 24.02.0
+  version: 24.03.0
   manager: conda
   platform: osx-64
   dependencies:
@@ -12123,24 +9746,24 @@ package:
     lcms2: '>=2.16,<3.0a0'
     libcurl: '>=8.5.0,<9.0a0'
     libcxx: '>=16'
-    libglib: '>=2.78.3,<3.0a0'
+    libglib: '>=2.78.4,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
     libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     nspr: '>=4.35,<5.0a0'
-    nss: '>=3.97,<4.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    nss: '>=3.98,<4.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     poppler-data: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.02.0-h0c752f9_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/poppler-24.03.0-h0c752f9_0.conda
   hash:
-    md5: 064e1d83d148b0ff5fa9ddd21141d0b1
-    sha256: 54400c2961eca96f14ecbb9ccdac457ef7f86ee6741e38aa71db47eee22b76b6
+    md5: 6b55d989edec2e1ea71236ca4cdd4960
+    sha256: 05c0e43fda42be7745a68681511125ee244f465a9515fe6d4b564a224ca3b46b
   category: main
   optional: false
 - name: poppler
-  version: 24.02.0
+  version: 24.03.0
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12152,24 +9775,24 @@ package:
     lcms2: '>=2.16,<3.0a0'
     libcurl: '>=8.5.0,<9.0a0'
     libcxx: '>=16'
-    libglib: '>=2.78.3,<3.0a0'
+    libglib: '>=2.78.4,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
     libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     nspr: '>=4.35,<5.0a0'
-    nss: '>=3.97,<4.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    nss: '>=3.98,<4.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     poppler-data: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-24.02.0-h896e6cb_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/poppler-24.03.0-h896e6cb_0.conda
   hash:
-    md5: 228b76f3de35d7bbe1374e52d1e0a5bb
-    sha256: c4d579795f329f1fe1b590d7cc3fc31d6b68f08e27b1f84e36ea3e9e05de5d6e
+    md5: 9ceb412621711e3ea8742015c69aa7f9
+    sha256: a68463831145e1faec9a39a39b1676379c8a67e9955ae8ff2bb4c7870a09df8e
   category: main
   optional: false
 - name: poppler
-  version: 24.02.0
+  version: 24.03.0
   manager: conda
   platform: win-64
   dependencies:
@@ -12177,21 +9800,21 @@ package:
     freetype: '>=2.12.1,<3.0a0'
     lcms2: '>=2.16,<3.0a0'
     libcurl: '>=8.5.0,<9.0a0'
-    libglib: '>=2.78.3,<3.0a0'
+    libglib: '>=2.78.4,<3.0a0'
     libiconv: '>=1.17,<2.0a0'
     libjpeg-turbo: '>=3.0.0,<4.0a0'
-    libpng: '>=1.6.42,<1.7.0a0'
+    libpng: '>=1.6.43,<1.7.0a0'
     libtiff: '>=4.6.0,<4.7.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openjpeg: '>=2.5.0,<3.0a0'
+    openjpeg: '>=2.5.2,<3.0a0'
     poppler-data: ''
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/poppler-24.02.0-hc2f3c52_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/poppler-24.03.0-hc2f3c52_0.conda
   hash:
-    md5: e740f88adfd0b75e6233066f6cbd4d82
-    sha256: 21e97633c56c9c1330433cfb20d12609a5f419ebe33474480f1b4c32048b298f
+    md5: 76d65f5a02e1ed1d914d8b7368e1a59e
+    sha256: e3d51588c6c97c0fa03c905049d5b9af139faad8e40545d809af44eef0a43f16
   category: main
   optional: false
 - name: poppler-data
@@ -12246,16 +9869,16 @@ package:
     krb5: '>=1.21.2,<1.22.0a0'
     libgcc-ng: '>=12'
     libpq: '16.2'
-    libxml2: '>=2.12.5,<3.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tzcode: ''
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.2-h7387d8b_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/postgresql-16.2-h82ecc9d_1.conda
   hash:
-    md5: 4e86738066b4966f0357f661b3691cae
-    sha256: 5b4fcfbd51957bb51fb1d2d28c3e9d8f4a50be0ac1be9c40083b1e9a39df7f3d
+    md5: 7a5806219d0f77ce8393375d040df065
+    sha256: 7fc52e69478973f173f055ade6c4087564362be9172c294b493a79671fef9a7e
   category: main
   optional: false
 - name: postgresql
@@ -12265,16 +9888,16 @@ package:
   dependencies:
     krb5: '>=1.21.2,<1.22.0a0'
     libpq: '16.2'
-    libxml2: '>=2.12.5,<3.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tzcode: ''
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.2-hbd19fd8_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/postgresql-16.2-h06f2bd8_1.conda
   hash:
-    md5: 00ed2daaa212835979fedc2cb7e1eac7
-    sha256: 8a9d1277488ee4c7e7c260d9423280782497930253a56bc9d88c94b2ec59748f
+    md5: fe36c4a9254176dde4ca696016c50aa8
+    sha256: 2a96af8385c51e97950ed00d802186069bf4933b3be111956508ab6be158d463
   category: main
   optional: false
 - name: postgresql
@@ -12284,16 +9907,16 @@ package:
   dependencies:
     krb5: '>=1.21.2,<1.22.0a0'
     libpq: '16.2'
-    libxml2: '>=2.12.5,<3.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tzcode: ''
     tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-16.2-h1d0603d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/postgresql-16.2-hf829917_1.conda
   hash:
-    md5: 29f3fd38f23da95692ab11af12fdb6da
-    sha256: 01b5bb78c909778fefca380bb808044850adba2972cd92f8fe6ead122a34fc45
+    md5: a80492a97dc9c6f05b4181b8ab4dfb14
+    sha256: cfc337097f145a3e527c45b2ab40663421480acc225c3eb997459a80e5e1f9ae
   category: main
   optional: false
 - name: postgresql
@@ -12303,16 +9926,16 @@ package:
   dependencies:
     krb5: '>=1.21.2,<1.22.0a0'
     libpq: '16.2'
-    libxml2: '>=2.12.5,<3.0a0'
+    libxml2: '>=2.12.6,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     openssl: '>=3.2.1,<4.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.2-h1beaf6b_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/postgresql-16.2-h94c9ec1_1.conda
   hash:
-    md5: 03519a736c44af579f0c364669329df1
-    sha256: 5443f216bf46d4d72a7a5b229db24e824112a01baa4ba727ffe7f0dc2d2b78c0
+    md5: c76ba206e82b0d0dbfc9d6d48b80053b
+    sha256: 35d632652bc965e5f7b6b4f9f8a36c6c399d1defc2e4f68841f42d5b9a51ee70
   category: main
   optional: false
 - name: proj
@@ -12443,194 +10066,194 @@ package:
   category: main
   optional: false
 - name: pyarrow
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: linux-64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libarrow-dataset: 15.0.0
-    libarrow-flight: 15.0.0
-    libarrow-flight-sql: 15.0.0
-    libarrow-gandiva: 15.0.0
-    libarrow-substrait: 15.0.0
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libarrow-dataset: 15.0.2
+    libarrow-flight: 15.0.2
+    libarrow-flight-sql: 15.0.2
+    libarrow-gandiva: 15.0.2
+    libarrow-substrait: 15.0.2
     libgcc-ng: '>=12'
-    libparquet: 15.0.0
+    libparquet: 15.0.2
     libstdcxx-ng: '>=12'
-    numpy: '>=1.26.3,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-15.0.0-py312h176e3d2_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-15.0.2-py312h176e3d2_1_cpu.conda
   hash:
-    md5: cb8002378347e5e8657ba16c226a82bf
-    sha256: 0a1a6c9c87215dc0c79e3080a3d37baa9ab253a3c53b2e5759023c4d931782e1
+    md5: e5340d2a8d88003d053b49e852459a4c
+    sha256: b1e6c813d5bb2fee372a8622f85219f97392b2cd684777aa4f782ec34f0f7e98
   category: main
   optional: false
 - name: pyarrow
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libarrow-dataset: 15.0.0
-    libarrow-flight: 15.0.0
-    libarrow-flight-sql: 15.0.0
-    libarrow-gandiva: 15.0.0
-    libarrow-substrait: 15.0.0
-    libcxx: '>=14'
-    libparquet: 15.0.0
-    numpy: '>=1.26.3,<2.0a0'
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libarrow-dataset: 15.0.2
+    libarrow-flight: 15.0.2
+    libarrow-flight-sql: 15.0.2
+    libarrow-gandiva: 15.0.2
+    libarrow-substrait: 15.0.2
+    libcxx: '>=16'
+    libparquet: 15.0.2
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-15.0.0-py312h40fbfea_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-15.0.2-py312hc4c33ac_1_cpu.conda
   hash:
-    md5: 64690ca104e005e4494f607d3ef30405
-    sha256: 9412fa37180a388ab0bed9296e990f032c517de01177ac0154f72274968f4f7f
+    md5: 31a48943b65f497d47afa9ba20f1ed08
+    sha256: 43c182aaadacb631b754ffef56a89cd8bf2be5afdc98c05c07223919b91e493e
   category: main
   optional: false
 - name: pyarrow
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libarrow-dataset: 15.0.0
-    libarrow-flight: 15.0.0
-    libarrow-flight-sql: 15.0.0
-    libarrow-gandiva: 15.0.0
-    libarrow-substrait: 15.0.0
-    libcxx: '>=14'
-    libparquet: 15.0.0
-    numpy: '>=1.26.3,<2.0a0'
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libarrow-dataset: 15.0.2
+    libarrow-flight: 15.0.2
+    libarrow-flight-sql: 15.0.2
+    libarrow-gandiva: 15.0.2
+    libarrow-substrait: 15.0.2
+    libcxx: '>=16'
+    libparquet: 15.0.2
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-15.0.0-py312h14a4a34_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-15.0.2-py312h1251918_1_cpu.conda
   hash:
-    md5: c8d529341e7182cb7377f311b0960e56
-    sha256: 31f4396600815b1d7aef1806f439a5491b472e3500a98c14032a35da8a7cd191
+    md5: 6ceb075409d206ef9c95601a65710ce2
+    sha256: 5b81c2edcf4d854468175154a97d31676cce5ee4aee224d0b575760966f41e57
   category: main
   optional: false
 - name: pyarrow
-  version: 15.0.0
+  version: 15.0.2
   manager: conda
   platform: win-64
   dependencies:
-    libarrow: 15.0.0
-    libarrow-acero: 15.0.0
-    libarrow-dataset: 15.0.0
-    libarrow-flight: 15.0.0
-    libarrow-flight-sql: 15.0.0
-    libarrow-gandiva: 15.0.0
-    libarrow-substrait: 15.0.0
-    libparquet: 15.0.0
-    numpy: '>=1.26.3,<2.0a0'
+    libarrow: 15.0.2
+    libarrow-acero: 15.0.2
+    libarrow-dataset: 15.0.2
+    libarrow-flight: 15.0.2
+    libarrow-flight-sql: 15.0.2
+    libarrow-gandiva: 15.0.2
+    libarrow-substrait: 15.0.2
+    libparquet: 15.0.2
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-15.0.0-py312h85e32bb_2_cpu.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/pyarrow-15.0.2-py312h85e32bb_1_cpu.conda
   hash:
-    md5: ce9f7c8089f3ae2acca541a683b93d73
-    sha256: 9642ff5752a8d4c7f3ee6efd06379559ec242811bc8e5d33b149915e2a19d9d9
+    md5: 20a1bf6c88b1494acc2245e9d92f427b
+    sha256: c50e4f26039ff880c38f72ba8454ccec62be4825cb78244424b552eef1d1ed1b
   category: main
   optional: false
 - name: pycparser
-  version: '2.21'
+  version: '2.22'
   manager: conda
   platform: linux-64
   dependencies:
-    python: 2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
   hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    md5: 844d9eb3b43095b031874477f7d70088
+    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
   category: main
   optional: false
 - name: pycparser
-  version: '2.21'
+  version: '2.22'
   manager: conda
   platform: osx-64
   dependencies:
-    python: 2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
   hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    md5: 844d9eb3b43095b031874477f7d70088
+    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
   category: main
   optional: false
 - name: pycparser
-  version: '2.21'
+  version: '2.22'
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: 2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
   hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    md5: 844d9eb3b43095b031874477f7d70088
+    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
   category: main
   optional: false
 - name: pycparser
-  version: '2.21'
+  version: '2.22'
   manager: conda
   platform: win-64
   dependencies:
-    python: 2.7.*|>=3.4
-  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.21-pyhd8ed1ab_0.tar.bz2
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
   hash:
-    md5: 076becd9e05608f8dc72757d5f3a91ff
-    sha256: 74c63fd03f1f1ea2b54e8bc529fd1a600aaafb24027b738d0db87909ee3a33dc
+    md5: 844d9eb3b43095b031874477f7d70088
+    sha256: 406001ebf017688b1a1554b49127ca3a4ac4626ec0fd51dc75ffa4415b720b64
   category: main
   optional: false
 - name: pyparsing
-  version: 3.1.1
+  version: 3.1.2
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
-    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
+    md5: b9a4dacf97241704529131a0dfc0494f
+    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
   category: main
   optional: false
 - name: pyparsing
-  version: 3.1.1
+  version: 3.1.2
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
-    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
+    md5: b9a4dacf97241704529131a0dfc0494f
+    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
   category: main
   optional: false
 - name: pyparsing
-  version: 3.1.1
+  version: 3.1.2
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
-    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
+    md5: b9a4dacf97241704529131a0dfc0494f
+    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
   category: main
   optional: false
 - name: pyparsing
-  version: 3.1.1
+  version: 3.1.2
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.1-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.1.2-pyhd8ed1ab_0.conda
   hash:
-    md5: 176f7d56f0cfe9008bdf1bccd7de02fb
-    sha256: 4a1332d634b6c2501a973655d68f08c9c42c0bd509c349239127b10572b8354b
+    md5: b9a4dacf97241704529131a0dfc0494f
+    sha256: 06c77cb03e5dde2d939b216c99dd2db52ea93a4c7c599f3882f136005c359c7b
   category: main
   optional: false
 - name: pyproj
@@ -12751,7 +10374,7 @@ package:
   category: main
   optional: false
 - name: pytest
-  version: 8.0.0
+  version: 8.1.1
   manager: conda
   platform: linux-64
   dependencies:
@@ -12759,17 +10382,17 @@ package:
     exceptiongroup: '>=1.0.0rc8'
     iniconfig: ''
     packaging: ''
-    pluggy: <2.0,>=1.4.0
+    pluggy: <2.0,>=1.4
     python: '>=3.8'
-    tomli: '>=1.0.0'
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.0-pyhd8ed1ab_0.conda
+    tomli: '>=1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5ba1cc5b924226349d4a49fb547b7579
-    sha256: 42717ca3e48c08b3098db01cbb3c04afd5fa67e67bad4691f2b88781269580a7
+    md5: 94ff09cdedcb7b17e9cd5097ee2cfcff
+    sha256: 3c481d6b54af1a33c32a3f3eaa3e0971955431e7023db55808740cd062271c73
   category: main
   optional: false
 - name: pytest
-  version: 8.0.0
+  version: 8.1.1
   manager: conda
   platform: osx-64
   dependencies:
@@ -12778,16 +10401,16 @@ package:
     iniconfig: ''
     python: '>=3.8'
     exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1.0.0'
-    pluggy: <2.0,>=1.4.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.0-pyhd8ed1ab_0.conda
+    pluggy: <2.0,>=1.4
+    tomli: '>=1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5ba1cc5b924226349d4a49fb547b7579
-    sha256: 42717ca3e48c08b3098db01cbb3c04afd5fa67e67bad4691f2b88781269580a7
+    md5: 94ff09cdedcb7b17e9cd5097ee2cfcff
+    sha256: 3c481d6b54af1a33c32a3f3eaa3e0971955431e7023db55808740cd062271c73
   category: main
   optional: false
 - name: pytest
-  version: 8.0.0
+  version: 8.1.1
   manager: conda
   platform: osx-arm64
   dependencies:
@@ -12796,16 +10419,16 @@ package:
     iniconfig: ''
     python: '>=3.8'
     exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1.0.0'
-    pluggy: <2.0,>=1.4.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.0-pyhd8ed1ab_0.conda
+    pluggy: <2.0,>=1.4
+    tomli: '>=1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5ba1cc5b924226349d4a49fb547b7579
-    sha256: 42717ca3e48c08b3098db01cbb3c04afd5fa67e67bad4691f2b88781269580a7
+    md5: 94ff09cdedcb7b17e9cd5097ee2cfcff
+    sha256: 3c481d6b54af1a33c32a3f3eaa3e0971955431e7023db55808740cd062271c73
   category: main
   optional: false
 - name: pytest
-  version: 8.0.0
+  version: 8.1.1
   manager: conda
   platform: win-64
   dependencies:
@@ -12814,16 +10437,16 @@ package:
     iniconfig: ''
     python: '>=3.8'
     exceptiongroup: '>=1.0.0rc8'
-    tomli: '>=1.0.0'
-    pluggy: <2.0,>=1.4.0
-  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.0.0-pyhd8ed1ab_0.conda
+    pluggy: <2.0,>=1.4
+    tomli: '>=1'
+  url: https://conda.anaconda.org/conda-forge/noarch/pytest-8.1.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 5ba1cc5b924226349d4a49fb547b7579
-    sha256: 42717ca3e48c08b3098db01cbb3c04afd5fa67e67bad4691f2b88781269580a7
+    md5: 94ff09cdedcb7b17e9cd5097ee2cfcff
+    sha256: 3c481d6b54af1a33c32a3f3eaa3e0971955431e7023db55808740cd062271c73
   category: main
   optional: false
 - name: python
-  version: 3.12.1
+  version: 3.12.2
   manager: conda
   platform: linux-64
   dependencies:
@@ -12833,80 +10456,80 @@ package:
     libffi: '>=3.4,<4.0a0'
     libgcc-ng: '>=12'
     libnsl: '>=2.0.1,<2.1.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.1,<4.0a0'
     libuuid: '>=2.38.1,<3.0a0'
     libxcrypt: '>=4.4.36'
     libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
     pip: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.1-hab00c5b_1_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.2-hab00c5b_0_cpython.conda
   hash:
-    md5: 0bab699354cbd66959550eb9b9866620
-    sha256: d44521b3ffd7edcad75bd55276ae3fb4cb07e63b2aa3545fef62bfda774b8a2b
+    md5: ad7b68400f3a6ebe72b00be093c7f301
+    sha256: ddb7a2d8d78046bda5d7631e6814f9468d2eb054e10f86f4648c9d1fdaa30c0f
   category: main
   optional: false
 - name: python
-  version: 3.12.1
+  version: 3.12.2
   manager: conda
   platform: osx-64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
     libexpat: '>=2.5.0,<3.0a0'
     libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.1,<4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
     pip: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.1-h9f0c242_1_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.2-h9f0c242_0_cpython.conda
   hash:
-    md5: 41d5549764b9f37199e6255e5e9daee6
-    sha256: d55c0875fc6f4228024d1fd0c4fcde8a61fdd4d852a98f3b05f121011a2fd753
+    md5: 0179b8007ba008cf5bec11f3b3853902
+    sha256: 7647ac06c3798a182a4bcb1ff58864f1ef81eb3acea6971295304c23e43252fb
   category: main
   optional: false
 - name: python
-  version: 3.12.1
+  version: 3.12.2
   manager: conda
   platform: osx-arm64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
     libexpat: '>=2.5.0,<3.0a0'
     libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.1,<4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     readline: '>=8.2,<9.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     xz: '>=5.2.6,<6.0a0'
     pip: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.1-hdf0ec26_1_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.2-hdf0ec26_0_cpython.conda
   hash:
-    md5: 7b5d48e25f131864762bfef1914d2014
-    sha256: c9bdc2478a983da8c1b965727889fe58e2ea594c6f280a73c822beab1926d40d
+    md5: 85e91138ae921a2771f57a50120272bd
+    sha256: ccd6c55a286d51d907c878ed2bfa7d1becce0fee71374a9386c5eb90d803ac72
   category: main
   optional: false
 - name: python
-  version: 3.12.1
+  version: 3.12.2
   manager: conda
   platform: win-64
   dependencies:
     bzip2: '>=1.0.8,<2.0a0'
     libexpat: '>=2.5.0,<3.0a0'
     libffi: '>=3.4,<4.0a0'
-    libsqlite: '>=3.44.2,<4.0a0'
+    libsqlite: '>=3.45.1,<4.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
     tk: '>=8.6.13,<8.7.0a0'
     tzdata: ''
     ucrt: '>=10.0.20348.0'
@@ -12914,162 +10537,62 @@ package:
     vc14_runtime: '>=14.29.30139'
     xz: '>=5.2.6,<6.0a0'
     pip: ''
-  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.1-h2628c8c_1_cpython.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/python-3.12.2-h2628c8c_0_cpython.conda
   hash:
-    md5: 19f49a5c0aea545792ad88bb40dc1ec9
-    sha256: e3c4d9a961dac0e15b501144b333ede8515bff83aec51f4815c575311053352f
+    md5: be8803e9f75a477df61d4aabea3c1246
+    sha256: b8eda863b48ae4531635e23fd15e759d93212b6204c6847d591e25fa5fd67477
   category: main
   optional: false
 - name: python-dateutil
-  version: 2.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-    six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd999d1cc9f79e67dbb855c8924c7984
-    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-  category: main
-  optional: false
-- name: python-dateutil
-  version: 2.8.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-    six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd999d1cc9f79e67dbb855c8924c7984
-    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-  category: main
-  optional: false
-- name: python-dateutil
-  version: 2.8.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-    six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd999d1cc9f79e67dbb855c8924c7984
-    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-  category: main
-  optional: false
-- name: python-dateutil
-  version: 2.8.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-    six: '>=1.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.8.2-pyhd8ed1ab_0.tar.bz2
-  hash:
-    md5: dd999d1cc9f79e67dbb855c8924c7984
-    sha256: 54d7785c7678166aa45adeaccfc1d2b8c3c799ca2dc05d4a82bb39b1968bd7da
-  category: main
-  optional: false
-- name: python-slugify
-  version: 8.0.4
+  version: 2.9.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.7'
-    text-unidecode: '>=1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
+    six: '>=1.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 4b11845622b3c3178c0e989235b53975
-    sha256: a1270bfd4f1d648766c8f95403f208e50d34af94761bc553a960102c6bff9fa0
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: main
   optional: false
-- name: python-slugify
-  version: 8.0.4
+- name: python-dateutil
+  version: 2.9.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
-    text-unidecode: '>=1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
+    six: '>=1.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 4b11845622b3c3178c0e989235b53975
-    sha256: a1270bfd4f1d648766c8f95403f208e50d34af94761bc553a960102c6bff9fa0
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: main
   optional: false
-- name: python-slugify
-  version: 8.0.4
+- name: python-dateutil
+  version: 2.9.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
-    text-unidecode: '>=1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
+    six: '>=1.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 4b11845622b3c3178c0e989235b53975
-    sha256: a1270bfd4f1d648766c8f95403f208e50d34af94761bc553a960102c6bff9fa0
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: main
   optional: false
-- name: python-slugify
-  version: 8.0.4
+- name: python-dateutil
+  version: 2.9.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
-    text-unidecode: '>=1.3'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-slugify-8.0.4-pyhd8ed1ab_0.conda
+    six: '>=1.5'
+  url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 4b11845622b3c3178c0e989235b53975
-    sha256: a1270bfd4f1d648766c8f95403f208e50d34af94761bc553a960102c6bff9fa0
-  category: main
-  optional: false
-- name: python-tzdata
-  version: '2024.1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 98206ea9954216ee7540f0c773f2104d
-    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
-  category: main
-  optional: false
-- name: python-tzdata
-  version: '2024.1'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 98206ea9954216ee7540f0c773f2104d
-    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
-  category: main
-  optional: false
-- name: python-tzdata
-  version: '2024.1'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: 98206ea9954216ee7540f0c773f2104d
-    sha256: 9da9a849d53705dee450b83507df1ca8ffea5f83bd21a215202221f1c492f8ad
-  category: main
-  optional: false
-- name: python-tzdata
-  version: '2024.1'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2024.1-pyhd8ed1ab_0.conda
-  hash:
-    md5: a61bf9ec79426938ff785eb69dbb1960
-    sha256: 4790787fe1f4e8da616edca4acf6a4f8ed4e7c6967aa31b920208fc8f95efcca
+    md5: 2cf4264fffb9e6eff6031c5b6884d61c
+    sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
   category: main
   optional: false
 - name: python-slugify
@@ -13265,7 +10788,7 @@ package:
   category: main
   optional: false
 - name: rdma-core
-  version: '50.0'
+  version: '51.0'
   manager: conda
   platform: linux-64
   dependencies:
@@ -13273,58 +10796,58 @@ package:
     libgcc-ng: '>=12'
     libnl: '>=3.9.0,<4.0a0'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-50.0-hd3aeb46_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/rdma-core-51.0-hd3aeb46_0.conda
   hash:
-    md5: 4594b391274e38f07c668acb45285a1f
-    sha256: 7cc75473895aa7d4fa1824ef94bd451768fa4a36a5046b3281ed2b1a6787853d
+    md5: 493598e1f28c01e316fda127715593aa
+    sha256: bcc774b60605b09701cfad41b2d6d9c3f052dd4adfc1f02bf1c929076f48fe30
   category: main
   optional: false
 - name: re2
-  version: 2023.06.02
+  version: 2023.09.01
   manager: conda
   platform: linux-64
   dependencies:
-    libre2-11: 2023.06.02
-  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.06.02-h2873b5e_0.conda
+    libre2-11: 2023.09.01
+  url: https://conda.anaconda.org/conda-forge/linux-64/re2-2023.09.01-h7f4b329_2.conda
   hash:
-    md5: bb2d5e593ef13fe4aff0bc9440f945ae
-    sha256: 3e0bfb04b6d43312d711c5b49dbc3c7660b2e6e681ed504b1b322794462a1bcd
+    md5: 8f70e36268dea8eb666ef14c29bd3cda
+    sha256: f0f520f57e6b58313e8c41abc7dfa48742a05f1681f05654558127b667c769a8
   category: main
   optional: false
 - name: re2
-  version: 2023.06.02
+  version: 2023.09.01
   manager: conda
   platform: osx-64
   dependencies:
-    libre2-11: 2023.06.02
-  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.06.02-hd34609a_0.conda
+    libre2-11: 2023.09.01
+  url: https://conda.anaconda.org/conda-forge/osx-64/re2-2023.09.01-hb168e87_2.conda
   hash:
-    md5: e498042c254db56d398b6ee858888b9d
-    sha256: dd749346b868ac9a8765cd18e102f808103330b3fc1fac5d267fbf4257ea31c9
+    md5: 266f8ca8528fc7e0fa31066c309ad864
+    sha256: 5739ed2cfa62ed7f828eb4b9e6e69ff1df56cb9a9aacdc296451a3cb647034eb
   category: main
   optional: false
 - name: re2
-  version: 2023.06.02
+  version: 2023.09.01
   manager: conda
   platform: osx-arm64
   dependencies:
-    libre2-11: 2023.06.02
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.06.02-h6135d0a_0.conda
+    libre2-11: 2023.09.01
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/re2-2023.09.01-h4cba328_2.conda
   hash:
-    md5: 8f23674174b155300696a2be8b5c1407
-    sha256: 963847258a82d9647311c5eb8829a49ac2161df12a304d5d6e61f788f0563442
+    md5: 0342882197116478a42fa4ea35af79c1
+    sha256: 0e0d44414381c39a7e6f3da442cb41c637df0dcb383a07425f19c19ccffa0118
   category: main
   optional: false
 - name: re2
-  version: 2023.06.02
+  version: 2023.09.01
   manager: conda
   platform: win-64
   dependencies:
-    libre2-11: 2023.06.02
-  url: https://conda.anaconda.org/conda-forge/win-64/re2-2023.06.02-hcbb65ff_0.conda
+    libre2-11: 2023.09.01
+  url: https://conda.anaconda.org/conda-forge/win-64/re2-2023.09.01-hd3b24a8_2.conda
   hash:
-    md5: aabaf2fe639029a25b39b6b14a1aa760
-    sha256: 97cfa7fe2e4111bd0915b8e14f1f1a00ee3fab14758ac89620c5e119c668e5b8
+    md5: ffeb985810bc7d103662e1465c758847
+    sha256: 929744a982215ea19f6f9a9d00c782969cd690bfddeeb650a39df1536af577fe
   category: main
   optional: false
 - name: readline
@@ -13485,20 +11008,20 @@ package:
   category: main
   optional: false
 - name: s2n
-  version: 1.4.3
+  version: 1.4.8
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
     openssl: '>=3.2.1,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.3-h06160fa_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.8-h06160fa_0.conda
   hash:
-    md5: 860332295eef2ef9fef370f365ea78b4
-    sha256: fd0b323f0915f249ba8c6dd5a22d8a340bdd00d835cfa336e9d5295df948b2d0
+    md5: 0240a49dffea6daea27aa388663edcab
+    sha256: 1068495f0f8f8b999dda339429dfaf5a8bd2e7a25bb386b6c39fd33ba01753fd
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.4.0
+  version: 1.4.1.post1
   manager: conda
   platform: linux-64
   dependencies:
@@ -13506,62 +11029,62 @@ package:
     joblib: '>=1.2.0'
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-    numpy: '>=1.26.3,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     scipy: ''
     threadpoolctl: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.4.0-py312h394d371_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.4.1.post1-py312h394d371_0.conda
   hash:
-    md5: c0dba83584b4fcd54b72e5ae76a2a0a8
-    sha256: 0300cd756b6c19bcd4885368dbb88c77f924ea578452233a36f0e731820c712b
+    md5: 7f50e0cc10407f2033d0305fee78490e
+    sha256: 0e18aec47e6cef8e34865417e2712b3fdacea1982a8b1acb6b1f0c185d9a4f07
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.4.0
+  version: 1.4.1.post1
   manager: conda
   platform: osx-64
   dependencies:
     joblib: '>=1.2.0'
-    libcxx: '>=15'
+    libcxx: '>=16'
     llvm-openmp: '>=17.0.6'
-    numpy: '>=1.26.3,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     scipy: ''
     threadpoolctl: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.4.0-py312h7167a34_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/scikit-learn-1.4.1.post1-py312h7167a34_0.conda
   hash:
-    md5: 523d2fcd0dd23c6a58fe2c4c7be735a1
-    sha256: 28fe6f0c56f0cbbb428b7808646d697efdaa98e3c09c13400b921aab9825d52a
+    md5: 0b8c6fb8f3f06d99cce439d79be6322d
+    sha256: 865a6f53b36f939df9b6e4580577171575fca260d33161c4e7115735a8a2fcdf
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.4.0
+  version: 1.4.1.post1
   manager: conda
   platform: osx-arm64
   dependencies:
     joblib: '>=1.2.0'
-    libcxx: '>=15'
+    libcxx: '>=16'
     llvm-openmp: '>=17.0.6'
-    numpy: '>=1.26.3,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     scipy: ''
     threadpoolctl: '>=2.0.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.4.0-py312hd4306f4_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.4.1.post1-py312hd4306f4_0.conda
   hash:
-    md5: 09adddeafb8aebe96a5d7e87f1ddcc05
-    sha256: 90d7bd1f275623f754113301e34b9cfcf677f2bd0174c59a185a2ff1d52f2922
+    md5: a61cfeba84450a9e8fa88fce295eb248
+    sha256: 1eaf9801e244562a6c590eae3d6ccf471b1e7f63c5faa717be40e5ee74735f1b
   category: main
   optional: false
 - name: scikit-learn
-  version: 1.4.0
+  version: 1.4.1.post1
   manager: conda
   platform: win-64
   dependencies:
     joblib: '>=1.2.0'
-    numpy: '>=1.26.3,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     scipy: ''
@@ -13569,10 +11092,10 @@ package:
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.4.0-py312hcacafb1_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/scikit-learn-1.4.1.post1-py312hcacafb1_0.conda
   hash:
-    md5: 51384461e75eedc12fef282a232cbac1
-    sha256: 017716da0c2a51f5e21a937d33807a334fe45d5077ddfc74431b3d1a81c687bf
+    md5: 4d4454b5c8ae82fc0a38895219d26315
+    sha256: 75cdb4d4b66198c591ae5e730d11b573122326dfe80d9d3232bc2d71eb1bbee1
   category: main
   optional: false
 - name: scipy
@@ -13657,115 +11180,115 @@ package:
   category: main
   optional: false
 - name: setuptools
-  version: 69.0.3
+  version: 69.2.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 40695fdfd15a92121ed2922900d0308b
-    sha256: 0fe2a0473ad03dac6c7f5c42ef36a8e90673c88a0350dfefdea4b08d43803db2
+    md5: da214ecd521a720a9d521c68047682dc
+    sha256: 78a75c75a5dacda6de5f4056c9c990141bdaf4f64245673a590594d00bc63713
   category: main
   optional: false
 - name: setuptools
-  version: 69.0.3
+  version: 69.2.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 40695fdfd15a92121ed2922900d0308b
-    sha256: 0fe2a0473ad03dac6c7f5c42ef36a8e90673c88a0350dfefdea4b08d43803db2
+    md5: da214ecd521a720a9d521c68047682dc
+    sha256: 78a75c75a5dacda6de5f4056c9c990141bdaf4f64245673a590594d00bc63713
   category: main
   optional: false
 - name: setuptools
-  version: 69.0.3
+  version: 69.2.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 40695fdfd15a92121ed2922900d0308b
-    sha256: 0fe2a0473ad03dac6c7f5c42ef36a8e90673c88a0350dfefdea4b08d43803db2
+    md5: da214ecd521a720a9d521c68047682dc
+    sha256: 78a75c75a5dacda6de5f4056c9c990141bdaf4f64245673a590594d00bc63713
   category: main
   optional: false
 - name: setuptools
-  version: 69.0.3
+  version: 69.2.0
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.0.3-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-69.2.0-pyhd8ed1ab_0.conda
   hash:
-    md5: 40695fdfd15a92121ed2922900d0308b
-    sha256: 0fe2a0473ad03dac6c7f5c42ef36a8e90673c88a0350dfefdea4b08d43803db2
+    md5: da214ecd521a720a9d521c68047682dc
+    sha256: 78a75c75a5dacda6de5f4056c9c990141bdaf4f64245673a590594d00bc63713
   category: main
   optional: false
 - name: shapely
-  version: 2.0.2
+  version: 2.0.3
   manager: conda
   platform: linux-64
   dependencies:
     geos: '>=3.12.1,<3.12.2.0a0'
     libgcc-ng: '>=12'
-    numpy: '>=1.26.0,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.2-py312h9e6bd2c_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/shapely-2.0.3-py312h9e6bd2c_0.conda
   hash:
-    md5: 187e6b3b69e7b38cd009614e86275b0e
-    sha256: e674bbe7e285d245583f8688c014ac0da1f6fd7ce5b5d771139a3e09ac6bf5ae
+    md5: 5e0580a84d702cda52c8b0245e4c14d2
+    sha256: 780c1f964f99454ed6034156deedd9b67373d54295434f77623ab884ce6b0f97
   category: main
   optional: false
 - name: shapely
-  version: 2.0.2
+  version: 2.0.3
   manager: conda
   platform: osx-64
   dependencies:
     geos: '>=3.12.1,<3.12.2.0a0'
-    numpy: '>=1.26.0,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.2-py312h8fb43f9_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/shapely-2.0.3-py312h8fb43f9_0.conda
   hash:
-    md5: 5e34f86775f26ca3b3c483fd9106acdb
-    sha256: cee61229345f314d83fa3cb4fb92c8b6302ece8c12fd9fe84d0672422970069e
+    md5: abad6d4900e92349375863ad7e162d1f
+    sha256: 4fb02761e26e36597bb0df763cbcd3e3cdb8e3c3786920807d9d6762ba66a130
   category: main
   optional: false
 - name: shapely
-  version: 2.0.2
+  version: 2.0.3
   manager: conda
   platform: osx-arm64
   dependencies:
     geos: '>=3.12.1,<3.12.2.0a0'
-    numpy: '>=1.26.0,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.2-py312h04e4829_1.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/shapely-2.0.3-py312h04e4829_0.conda
   hash:
-    md5: aaf872e4c9d47ffcdc7ff9878c6e72aa
-    sha256: 4f9dd83cde73ec8dff7a5f6c942ce0d798a38620ef711907c48da2e5e23d317c
+    md5: fba7689345d909823cbaa5ec9056a5f9
+    sha256: 42e93fc8e6f20e4eef99157512e1037f1bedff123aab8ecf76fbb373f9b0b452
   category: main
   optional: false
 - name: shapely
-  version: 2.0.2
+  version: 2.0.3
   manager: conda
   platform: win-64
   dependencies:
     geos: '>=3.12.1,<3.12.2.0a0'
-    numpy: '>=1.26.0,<2.0a0'
+    numpy: '>=1.26.4,<2.0a0'
     python: '>=3.12,<3.13.0a0'
     python_abi: 3.12.*
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.2-py312h7d70906_1.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/shapely-2.0.3-py312h7d70906_0.conda
   hash:
-    md5: cb8c2d0784408f00a15bc6a7bf8992df
-    sha256: c097eac394e0dc4332db18fc869ba3f3308001fcd3f5cca0b97278a589aaf096
+    md5: 246e222db0eb7cd8d82a543b708176a7
+    sha256: 76b66f2f5be07c2d809c02c7224db359d189f3e24a3658a9393f5b47598996ba
   category: main
   optional: false
 - name: six
@@ -13915,173 +11438,122 @@ package:
     sha256: 54ae221033db8fbcd4998ccb07f3c3828b4d77e73b0c72b18c1d6a507059059c
   category: main
   optional: false
+- name: spdlog
+  version: 1.12.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    fmt: '>=10.1.1,<11.0a0'
+    libgcc-ng: '>=12'
+    libstdcxx-ng: '>=12'
+  url: https://conda.anaconda.org/conda-forge/linux-64/spdlog-1.12.0-hd2e6256_2.conda
+  hash:
+    md5: f37afc6ce10d45b9fae2f55ddc635b9f
+    sha256: 34c2ac3ecafc109ea659087f2a429b8fd7c557eb75d072e723a9954472726e62
+  category: main
+  optional: false
+- name: spdlog
+  version: 1.12.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=10.9'
+    fmt: '>=10.1.1,<11.0a0'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-64/spdlog-1.12.0-h8dd852c_2.conda
+  hash:
+    md5: 1be852e792cca50421504cee933e3063
+    sha256: 3bce42d94b4cd5672bde68ec47374e558b2bc481621f759f70b56bf3da12c31f
+  category: main
+  optional: false
+- name: spdlog
+  version: 1.12.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=10.9'
+    fmt: '>=10.1.1,<11.0a0'
+    libcxx: '>=16.0.6'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/spdlog-1.12.0-he64bfa9_2.conda
+  hash:
+    md5: ef84dce6d582965c3fc1e4a52ba51114
+    sha256: 504a85024b9506de38801250a43da5360b8de87364b9bc4b70777ee9cc830429
+  category: main
+  optional: false
+- name: spdlog
+  version: 1.12.0
+  manager: conda
+  platform: win-64
+  dependencies:
+    fmt: '>=10.1.1,<11.0a0'
+    ucrt: '>=10.0.20348.0'
+    vc: '>=14.2,<15'
+    vc14_runtime: '>=14.29.30139'
+  url: https://conda.anaconda.org/conda-forge/win-64/spdlog-1.12.0-h64d2f7d_2.conda
+  hash:
+    md5: e039fdff30fd25fbfc7cb91755d80a4f
+    sha256: 4b582768ebb9d234c0a9e0eae482733f167d53e316f0f48aac19a028a83a8570
+  category: main
+  optional: false
 - name: sqlite
-  version: 3.45.1
+  version: 3.45.2
   manager: conda
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libsqlite: 3.45.1
+    libsqlite: 3.45.2
     libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
     readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.45.1-h2c6b66d_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.45.2-h2c6b66d_0.conda
   hash:
-    md5: 93acf31b379acebada263b9bce3dc6ed
-    sha256: a7cbde68eff5d2ec9bb1b5f2604a523949048a9b5335588eac2d893fd0dd5200
+    md5: 1423efca06ed343c1da0fc429bae0779
+    sha256: 22d2692c82b73480c9adc80472bfb241262586edaf1dac1a7504434e47185d3c
   category: main
   optional: false
 - name: sqlite
-  version: 3.45.1
+  version: 3.45.2
   manager: conda
   platform: osx-64
   dependencies:
-    libsqlite: 3.45.1
+    libsqlite: 3.45.2
     libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
     readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.45.1-h7461747_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.45.2-h7461747_0.conda
   hash:
-    md5: 239ff6ffc3ee45898db19e3cbbf40f88
-    sha256: ce0908a02a1965854dde0022f5ba9b986324077ba4835a3c990463ed762e6e8f
+    md5: fc4dae09f6b38084f3bfc87c77032584
+    sha256: c9c1b7d6025d5efa74f4ddbda1ae72a721f041ad3d4a6ec3dda600befe9dffaa
   category: main
   optional: false
 - name: sqlite
-  version: 3.45.1
+  version: 3.45.2
   manager: conda
   platform: osx-arm64
   dependencies:
-    libsqlite: 3.45.1
+    libsqlite: 3.45.2
     libzlib: '>=1.2.13,<1.3.0a0'
     ncurses: '>=6.4,<7.0a0'
     readline: '>=8.2,<9.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.45.1-hf2abe2d_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/sqlite-3.45.2-hf2abe2d_0.conda
   hash:
-    md5: 58918f7a593a143c2f305b832c8802f4
-    sha256: 9dc20bca83b44cabedefab92b4484fd41bef36b6c73cd3b31506d209ba0d5c2f
+    md5: 67af40712ec3989036429398b69ec206
+    sha256: 43f30a40494bd631e7a19fa258115c09a3fed540e5398ba3a8da66f3e48942ca
   category: main
   optional: false
 - name: sqlite
-  version: 3.45.1
+  version: 3.45.2
   manager: conda
   platform: win-64
   dependencies:
-    libsqlite: 3.45.1
+    libsqlite: 3.45.2
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
-  url: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.45.1-hcfcfb64_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.45.2-hcfcfb64_0.conda
   hash:
-    md5: 3c6f2dc59bcde87ee1de006f22ecc40a
-    sha256: e77d529803d11743306b57d871c1f168da0eaa5a405591a4a53139a9a10cda0c
-  category: main
-  optional: false
-- name: stack_data
-  version: 0.6.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    asttokens: ''
-    executing: ''
-    pure_eval: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-  category: main
-  optional: false
-- name: stack_data
-  version: 0.6.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    asttokens: ''
-    executing: ''
-    pure_eval: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-  category: main
-  optional: false
-- name: stack_data
-  version: 0.6.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    asttokens: ''
-    executing: ''
-    pure_eval: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-  category: main
-  optional: false
-- name: stack_data
-  version: 0.6.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    asttokens: ''
-    executing: ''
-    pure_eval: ''
-    python: '>=3.5'
-  url: https://conda.anaconda.org/conda-forge/noarch/stack_data-0.6.2-pyhd8ed1ab_0.conda
-  hash:
-    md5: e7df0fdd404616638df5ece6e69ba7af
-    sha256: a58433e75229bec39f3be50c02efbe9b7083e53a1f31d8ee247564f370191eec
-  category: main
-  optional: false
-- name: suds
-  version: 1.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/suds-1.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 40afbd405da1a84722aa3d26a5e295fc
-    sha256: 6101c91bf7c1c61631802f75916832c3eb2a678645f5f58049364a88818f2a21
-  category: main
-  optional: false
-- name: suds
-  version: 1.1.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/suds-1.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 40afbd405da1a84722aa3d26a5e295fc
-    sha256: 6101c91bf7c1c61631802f75916832c3eb2a678645f5f58049364a88818f2a21
-  category: main
-  optional: false
-- name: suds
-  version: 1.1.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/suds-1.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 40afbd405da1a84722aa3d26a5e295fc
-    sha256: 6101c91bf7c1c61631802f75916832c3eb2a678645f5f58049364a88818f2a21
-  category: main
-  optional: false
-- name: suds
-  version: 1.1.2
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.6'
-  url: https://conda.anaconda.org/conda-forge/noarch/suds-1.1.2-pyhd8ed1ab_1.tar.bz2
-  hash:
-    md5: 40afbd405da1a84722aa3d26a5e295fc
-    sha256: 6101c91bf7c1c61631802f75916832c3eb2a678645f5f58049364a88818f2a21
+    md5: 329d25303ed8299f8f900344cd69a705
+    sha256: 2d54418dff5cc35d3c5b99d7094d6ea9956cacbc9777df46c74020c4f8e32b39
   category: main
   optional: false
 - name: tbb
@@ -14147,201 +11619,169 @@ package:
     sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
   category: main
   optional: false
-- name: text-unidecode
-  version: '1.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
-  hash:
-    md5: ba8aba332d8868897ce44ad74015a7fe
-    sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
-  category: main
-  optional: false
-- name: text-unidecode
-  version: '1.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
-  hash:
-    md5: ba8aba332d8868897ce44ad74015a7fe
-    sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
-  category: main
-  optional: false
-- name: text-unidecode
-  version: '1.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
-  hash:
-    md5: ba8aba332d8868897ce44ad74015a7fe
-    sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
-  category: main
-  optional: false
-- name: text-unidecode
-  version: '1.3'
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.4'
-  url: https://conda.anaconda.org/conda-forge/noarch/text-unidecode-1.3-pyhd8ed1ab_1.conda
-  hash:
-    md5: ba8aba332d8868897ce44ad74015a7fe
-    sha256: db64669a918dec8c744f80a85b9c82216b79298256c7c8bd19bdba54a02f8914
-  category: main
-  optional: false
 - name: threadpoolctl
-  version: 3.3.0
+  version: 3.4.0
   manager: conda
   platform: linux-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
   hash:
-    md5: 698d2d2b621640bddb9191f132967c9f
-    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
+    md5: b296278eef667c673bf51de6535bad88
+    sha256: 4f4ad4f2a4ee8875cf2cb9c80abf4c7383e5e53cfec41104da7058569d9063b7
   category: main
   optional: false
 - name: threadpoolctl
-  version: 3.3.0
+  version: 3.4.0
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
   hash:
-    md5: 698d2d2b621640bddb9191f132967c9f
-    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
+    md5: b296278eef667c673bf51de6535bad88
+    sha256: 4f4ad4f2a4ee8875cf2cb9c80abf4c7383e5e53cfec41104da7058569d9063b7
   category: main
   optional: false
 - name: threadpoolctl
-  version: 3.3.0
+  version: 3.4.0
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
   hash:
-    md5: 698d2d2b621640bddb9191f132967c9f
-    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
+    md5: b296278eef667c673bf51de6535bad88
+    sha256: 4f4ad4f2a4ee8875cf2cb9c80abf4c7383e5e53cfec41104da7058569d9063b7
   category: main
   optional: false
 - name: threadpoolctl
-  version: 3.3.0
+  version: 3.4.0
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.8'
-  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.3.0-pyhc1e730c_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/threadpoolctl-3.4.0-pyhc1e730c_0.conda
   hash:
-    md5: 698d2d2b621640bddb9191f132967c9f
-    sha256: 5ba8bd3f2d49b3b860eb4481ca9505c57d4427212eb12cadd2b351309d5c28e6
+    md5: b296278eef667c673bf51de6535bad88
+    sha256: 4f4ad4f2a4ee8875cf2cb9c80abf4c7383e5e53cfec41104da7058569d9063b7
   category: main
   optional: false
 - name: tiledb
-  version: 2.19.1
+  version: 2.21.1
   manager: conda
   platform: linux-64
   dependencies:
-    azure-core-cpp: '>=1.10.3,<1.11.0a0'
-    azure-storage-blobs-cpp: '>=12.10.0,<13.0a0'
-    azure-storage-common-cpp: '>=12.5.0,<13.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    aws-sdk-cpp: '>=1.11.267,<1.11.268.0a0'
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    azure-storage-blobs-cpp: '>=12.10.0,<12.10.1.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
+    fmt: '>=10.2.1,<11.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
     libgcc-ng: '>=12'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
+    libgoogle-cloud: '>=2.22.0,<2.23.0a0'
+    libgoogle-cloud-storage: '>=2.22.0,<2.23.0a0'
     libstdcxx-ng: '>=12'
-    libxml2: '>=2.12.4,<3.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    spdlog: '>=1.12.0,<1.13.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.19.1-h4386cac_0.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/tiledb-2.21.1-ha9641ad_1.conda
   hash:
-    md5: 8d16e7b2529607a12aa6722c7a7c7356
-    sha256: c75ff0cdcf3e3dac837739e056c2dbd74f0b1055ed17ac1523856c44f208e5c1
+    md5: 0453962dfed0265093929b52f885b190
+    sha256: 7f5ee10edebe594158d935adc89c5c12f2cf4ba28a2a7ccba4dab3b9953de43c
   category: main
   optional: false
 - name: tiledb
-  version: 2.19.1
+  version: 2.21.1
   manager: conda
   platform: osx-64
   dependencies:
     __osx: '>=10.13'
-    azure-core-cpp: '>=1.10.3,<1.11.0a0'
-    azure-storage-blobs-cpp: '>=12.10.0,<13.0a0'
-    azure-storage-common-cpp: '>=12.5.0,<13.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    aws-sdk-cpp: '>=1.11.267,<1.11.268.0a0'
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    azure-storage-blobs-cpp: '>=12.10.0,<12.10.1.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libcxx: '>=15'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libxml2: '>=2.12.4,<3.0a0'
+    fmt: '>=10.2.1,<11.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
+    libcxx: '>=16'
+    libgoogle-cloud: '>=2.22.0,<2.23.0a0'
+    libgoogle-cloud-storage: '>=2.22.0,<2.23.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    spdlog: '>=1.12.0,<1.13.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.19.1-h8fd0293_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-64/tiledb-2.21.1-h0d80af6_1.conda
   hash:
-    md5: ae08850e4a0e58203a1cbfb14b452258
-    sha256: ccfd5f791c71c8484fd1b6d6402bc7330ea29c1f1d71abcd4c5fdcbe2daa4659
+    md5: 238c63dbc6c0ad46c0b17e34812503bd
+    sha256: 2368f0d93fab2d1206a9575e2c930f884968f16e0a8069fbb0e88fb9bf6b7568
   category: main
   optional: false
 - name: tiledb
-  version: 2.19.1
+  version: 2.21.1
   manager: conda
   platform: osx-arm64
   dependencies:
-    azure-core-cpp: '>=1.10.3,<1.11.0a0'
-    azure-storage-blobs-cpp: '>=12.10.0,<13.0a0'
-    azure-storage-common-cpp: '>=12.5.0,<13.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    aws-sdk-cpp: '>=1.11.267,<1.11.268.0a0'
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    azure-storage-blobs-cpp: '>=12.10.0,<12.10.1.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libcxx: '>=15'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libxml2: '>=2.12.4,<3.0a0'
+    fmt: '>=10.2.1,<11.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
+    libcxx: '>=16'
+    libgoogle-cloud: '>=2.22.0,<2.23.0a0'
+    libgoogle-cloud-storage: '>=2.22.0,<2.23.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    spdlog: '>=1.12.0,<1.13.0a0'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.19.1-h49d9ff7_0.conda
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tiledb-2.21.1-hbfef6ee_1.conda
   hash:
-    md5: dcd5b377b1d7784909acffd3bb6ca282
-    sha256: 9264b07951317c6ce50d5b5e0f02fb4cbddd45cb26de09edb7bd267424adc6e4
+    md5: 8559b34c7ba8001f5ba173d129683be1
+    sha256: 00bea8634468cd45b0855a376d1f0927ea4cdc860fdaae6af9bc912e92511d4e
   category: main
   optional: false
 - name: tiledb
-  version: 2.19.1
+  version: 2.21.1
   manager: conda
   platform: win-64
   dependencies:
-    azure-core-cpp: '>=1.10.3,<1.11.0a0'
-    azure-storage-blobs-cpp: '>=12.10.0,<13.0a0'
-    azure-storage-common-cpp: '>=12.5.0,<13.0a0'
+    aws-crt-cpp: '>=0.26.4,<0.26.5.0a0'
+    aws-sdk-cpp: '>=1.11.267,<1.11.268.0a0'
+    azure-core-cpp: '>=1.11.1,<1.11.2.0a0'
+    azure-storage-blobs-cpp: '>=12.10.0,<12.10.1.0a0'
+    azure-storage-common-cpp: '>=12.5.0,<12.5.1.0a0'
     bzip2: '>=1.0.8,<2.0a0'
-    libabseil: '>=20230802.1,<20230803.0a0'
+    fmt: '>=10.2.1,<11.0a0'
+    libabseil: '>=20240116.1,<20240117.0a0'
     libcrc32c: '>=1.1.2,<1.2.0a0'
-    libcurl: '>=8.5.0,<9.0a0'
-    libgoogle-cloud: '>=2.12.0,<2.13.0a0'
-    libxml2: '>=2.12.4,<3.0a0'
+    libcurl: '>=8.6.0,<9.0a0'
+    libgoogle-cloud: '>=2.22.0,<2.23.0a0'
+    libgoogle-cloud-storage: '>=2.22.0,<2.23.0a0'
     libzlib: '>=1.2.13,<1.3.0a0'
     lz4-c: '>=1.9.3,<1.10.0a0'
-    openssl: '>=3.2.0,<4.0a0'
+    openssl: '>=3.2.1,<4.0a0'
+    spdlog: '>=1.12.0,<1.13.0a0'
     ucrt: '>=10.0.20348.0'
     vc: '>=14.2,<15'
     vc14_runtime: '>=14.29.30139'
     zstd: '>=1.5.5,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.19.1-h2657894_0.conda
+  url: https://conda.anaconda.org/conda-forge/win-64/tiledb-2.21.1-h25b666a_1.conda
   hash:
-    md5: 4dda2b1302437c7e06cf0cfca1bb16b1
-    sha256: 01ab52856318cbd7192bafdc9cf5461e143811ba0ed048ea531c0e313d6b4a2d
+    md5: 39170998eb988862a3cb234e1f385fcf
+    sha256: 34b0a0ea6b07f4f152d7a22c69a2f4780a57c11be93d2f5818e3243e30a51889
   category: main
   optional: false
 - name: tk
@@ -14539,13 +11979,12 @@ package:
   platform: linux-64
   dependencies:
     libgcc-ng: '>=12'
-    libnuma: '>=2.0.16,<3.0a0'
     libstdcxx-ng: '>=12'
-    rdma-core: '>=49'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-h75e419f_3.conda
+    rdma-core: '>=51.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ucx-1.15.0-ha691c75_8.conda
   hash:
-    md5: 5baf4efbca923cdf73490c62cc7de1e2
-    sha256: 7b5ccea54cac81bda2704e1c4cf06dba17dd683871e785fa11a1788ed289be9a
+    md5: 3f9bc6137b240642504a6c9b07a10c25
+    sha256: 85b40ac6607c9e4e32bcb13e95da41ff48a10f813df0c1e74ff32412e1f7da35
   category: main
   optional: false
 - name: uriparser
@@ -14555,10 +11994,10 @@ package:
   dependencies:
     libgcc-ng: '>=12'
     libstdcxx-ng: '>=12'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.7-hcb278e6_1.conda
+  url: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.7-h59595ed_1.conda
   hash:
-    md5: 2c46deb08ba9b10e90d0a6401ad65deb
-    sha256: bc7670384fc3e519b376eab25b2c747afe392b243f17e881075231f4a0f2e5a0
+    md5: c5edf07141147789784f89d5b4e4a9ad
+    sha256: ec997599b6dcfef34242c67b695c4704d9ba6cb0b9de8f390defa475a95cdb3f
   category: main
   optional: false
 - name: uriparser
@@ -14566,11 +12005,11 @@ package:
   manager: conda
   platform: osx-64
   dependencies:
-    libcxx: '>=14.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.7-hf0c8a7f_1.conda
+    libcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/osx-64/uriparser-0.9.7-he965462_1.conda
   hash:
-    md5: 998073b0ccb5f99d07d2089cf06363b3
-    sha256: faf0f7919851960bbb1d18d977f62082c0e4dc8f26e348d702e8a2dba53a4c37
+    md5: a342f2d5573ebdb1cba60ef2947c1b7f
+    sha256: 1f3563325ce2f9b28b6dfbc703f3cac4d36095d2103c40648338533f4cb80b63
   category: main
   optional: false
 - name: uriparser
@@ -14578,11 +12017,11 @@ package:
   manager: conda
   platform: osx-arm64
   dependencies:
-    libcxx: '>=14.0.6'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.7-hb7217d7_1.conda
+    libcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.7-h13dd4ca_1.conda
   hash:
-    md5: 4fe532e3c6b0cfa5365eb01743d32578
-    sha256: bedd03f3bb30b73ae7b0dc9626f1371a8568ce6d41303df3e8299688428dfa94
+    md5: df83a53820f413eb8b14045433a2d587
+    sha256: 019103df9eec86c9afa92dec21a849e63d57bfa9125ca811e68b78dab224c4ee
   category: main
   optional: false
 - name: uriparser
@@ -14600,59 +12039,59 @@ package:
   category: main
   optional: false
 - name: urllib3
-  version: 2.2.0
+  version: 2.2.1
   manager: conda
   platform: linux-64
   dependencies:
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
     python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 6a7e0694921f668a030d52f0c47baebd
-    sha256: 61a8a3bd36d235c349aedaf1aa6a79cce15d6fe89dca4bb593b596d0211513c6
+    md5: 08807a87fa7af10754d46f63b368e016
+    sha256: d4009dcc9327684d6409706ce17656afbeae690d8522d3c9bc4df57649a352cd
   category: main
   optional: false
 - name: urllib3
-  version: 2.2.0
+  version: 2.2.1
   manager: conda
   platform: osx-64
   dependencies:
     python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 6a7e0694921f668a030d52f0c47baebd
-    sha256: 61a8a3bd36d235c349aedaf1aa6a79cce15d6fe89dca4bb593b596d0211513c6
+    md5: 08807a87fa7af10754d46f63b368e016
+    sha256: d4009dcc9327684d6409706ce17656afbeae690d8522d3c9bc4df57649a352cd
   category: main
   optional: false
 - name: urllib3
-  version: 2.2.0
+  version: 2.2.1
   manager: conda
   platform: osx-arm64
   dependencies:
     python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 6a7e0694921f668a030d52f0c47baebd
-    sha256: 61a8a3bd36d235c349aedaf1aa6a79cce15d6fe89dca4bb593b596d0211513c6
+    md5: 08807a87fa7af10754d46f63b368e016
+    sha256: d4009dcc9327684d6409706ce17656afbeae690d8522d3c9bc4df57649a352cd
   category: main
   optional: false
 - name: urllib3
-  version: 2.2.0
+  version: 2.2.1
   manager: conda
   platform: win-64
   dependencies:
     python: '>=3.7'
     brotli-python: '>=1.0.9'
     pysocks: '>=1.5.6,<2.0,!=1.5.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.0-pyhd8ed1ab_0.conda
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.1-pyhd8ed1ab_0.conda
   hash:
-    md5: 6a7e0694921f668a030d52f0c47baebd
-    sha256: 61a8a3bd36d235c349aedaf1aa6a79cce15d6fe89dca4bb593b596d0211513c6
+    md5: 08807a87fa7af10754d46f63b368e016
+    sha256: d4009dcc9327684d6409706ce17656afbeae690d8522d3c9bc4df57649a352cd
   category: main
   optional: false
 - name: vc
@@ -14692,99 +12131,51 @@ package:
   category: main
   optional: false
 - name: wheel
-  version: 0.42.0
+  version: 0.43.0
   manager: conda
   platform: linux-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
+    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
+    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
   category: main
   optional: false
 - name: wheel
-  version: 0.42.0
+  version: 0.43.0
   manager: conda
   platform: osx-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
+    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
+    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
   category: main
   optional: false
 - name: wheel
-  version: 0.42.0
+  version: 0.43.0
   manager: conda
   platform: osx-arm64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
+    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
+    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
   category: main
   optional: false
 - name: wheel
-  version: 0.42.0
+  version: 0.43.0
   manager: conda
   platform: win-64
   dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.42.0-pyhd8ed1ab_0.conda
+    python: '>=3.8'
+  url: https://conda.anaconda.org/conda-forge/noarch/wheel-0.43.0-pyhd8ed1ab_1.conda
   hash:
-    md5: 1cdea58981c5cbc17b51973bcaddcea7
-    sha256: 80be0ccc815ce22f80c141013302839b0ed938a2edb50b846cf48d8a8c1cfa01
-  category: main
-  optional: false
-- name: widgetsnbextension
-  version: 4.0.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.10-pyhd8ed1ab_0.conda
-  hash:
-    md5: 521f489e3babeddeec638c2add7e9e64
-    sha256: 981b06c76a1a86bb84be09522768be0458274926b22f4b0225dfcdd30a6593e0
-  category: main
-  optional: false
-- name: widgetsnbextension
-  version: 4.0.10
-  manager: conda
-  platform: osx-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.10-pyhd8ed1ab_0.conda
-  hash:
-    md5: 521f489e3babeddeec638c2add7e9e64
-    sha256: 981b06c76a1a86bb84be09522768be0458274926b22f4b0225dfcdd30a6593e0
-  category: main
-  optional: false
-- name: widgetsnbextension
-  version: 4.0.10
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.10-pyhd8ed1ab_0.conda
-  hash:
-    md5: 521f489e3babeddeec638c2add7e9e64
-    sha256: 981b06c76a1a86bb84be09522768be0458274926b22f4b0225dfcdd30a6593e0
-  category: main
-  optional: false
-- name: widgetsnbextension
-  version: 4.0.10
-  manager: conda
-  platform: win-64
-  dependencies:
-    python: '>=3.7'
-  url: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.10-pyhd8ed1ab_0.conda
-  hash:
-    md5: 521f489e3babeddeec638c2add7e9e64
-    sha256: 981b06c76a1a86bb84be09522768be0458274926b22f4b0225dfcdd30a6593e0
+    md5: 0b5293a157c2b5cd513dd1b03d8d3aae
+    sha256: cb318f066afd6fd64619f14c030569faf3f53e6f50abf743b4c865e7d95b96bc
   category: main
   optional: false
 - name: win_inet_pton

--- a/environment.yml
+++ b/environment.yml
@@ -5,18 +5,12 @@ dependencies:
   - python=3.12
   - bs4
   - ckanapi
-  - eccodes
   - fake-useragent
-  - fiscalyear
   - geopandas>=0.13.2
-  - jinja2
-  - jupyter
+  - joblib
   - lxml
-  - owslib
   - pandas
-  - pdbufr
   - pdfminer.six
   - pyarrow
   - pytest
   - requests
-  - suds

--- a/ioos_metrics/__init__.py
+++ b/ioos_metrics/__init__.py
@@ -1,0 +1,10 @@
+"""The IOOS metrics builder.
+
+Just run:
+
+from  ioos_metrics.ioos_metrics import update_metrics
+
+df = update_metrics()
+
+
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,29 @@
 [tool.ruff]
-select = [
-    "A", # flake8-builtins
-    "B", # flake8-bugbear
-    "C4", # flake8-comprehensions
-    "F", # flakes
-    "I", # import sorting
-    "T20", # flake8-print
-    "UP", # upgrade
+target-version = "py312"
+lint.select = ["ALL"]
+line-length = 120
+exclude=[
+    "website/*",
+    "read_bufr.py",
+    "btn_metrics.py",
+    "gts_atn_metrics.py",
+    "gts_regional_metrics.py",
 ]
-target-version = "py38"
-line-length = 79
+
+lint.ignore = [
+    "G004",  # logging-f-string
+    "PD901",  # Avoid using the generic variable name `df` for DataFrames
+    "ANN201",  # Missing return type annotation for public function
+    "ANN001",  # Missing type annotation for function argument
+    "D401",  # First line of docstring should be in imperative mood
+    "D205",  # 1 blank line required between summary line and description
+    ]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"test_*.py" = [
+    "S101",  # Use of assert detected
+    "D103",  # Missing docstring in public function
+    "INP001",  # File is part of an implicit namespace package
+]
+[tool.ruff.lint.pycodestyle]
+max-doc-length = 180

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,6 @@
+"""Test metrics."""
+
+
 import sys
 
 import pandas as pd
@@ -22,7 +25,7 @@ from ioos_metrics.ioos_metrics import (
 )
 
 
-@pytest.fixture
+@pytest.fixture()
 def df_previous_metrics():
     return ioos_metrics.previous_metrics()
 


### PR DESCRIPTION
Implements a parallel job execution for the different metrics. We lose the independent error log for the services we query but we can keep that as a debug mode only in the test suit.

Ported from #54:
- [X] Parallelize `update_metrics`
TODO (moved to #57):
- [ ] HF Radar Stations  # This is a hardcoded number in the notebook (165), is that still valid @MathewBiddle?
- [ ] National Platforms  # Lots of services and should be into a separate module
- [ ] NGDAC Glider Days  # Implemented but must change to glider-data-days