### PR TITLE
Fix get_oap()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     - id: check-added-large-files
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.4.0
+  rev: v2.4.1
   hooks:
     - id: codespell
       exclude: >
@@ -36,7 +36,7 @@ repos:
     - id: add-trailing-comma
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.3
+  rev: v0.9.6
   hooks:
     - id: ruff
       args: ["--fix", "--show-fixes"]

--- a/ioos_metrics/national_platforms.py
+++ b/ioos_metrics/national_platforms.py
@@ -138,16 +138,17 @@ def get_oap():
     * https://cdip.ucsd.edu/m/stn_table
       Includes overlap with the RAs and other programs
 
-    See buoys and moorings at https://oceanacidification.noaa.gov/WhatWeDo/Data.aspx
+    See buoys and moorings at https://oceanacidification.noaa.gov/ocean-acidification-data/
 
     """
-    url = "https://oceanacidification.noaa.gov/WhatWeDo/Data.aspx"
+    url = "https://oceanacidification.noaa.gov/ocean-acidification-data"
     html = requests.get(url, timeout=10).text
     soup = BeautifulSoup(html, "html.parser")
-    text = soup.find_all(attrs={"data-id": "4fa1cacd"})[0].find_all("h6")[0].text
+    text = soup.find(attrs={"class": "dce-osm-wrapper"})
+    jsmap = text.attrs["data_repeater"]
 
-    res = [int(i) for i in text.split() if i.isdigit()]
-    return int(res[0])
+    res = len([word for word in jsmap.lower().split() if word.startswith("data<\\/a><\\/strong><\\/p>")])
+    return res
 
 
 @functools.lru_cache(maxsize=128)


### PR DESCRIPTION
@MathewBiddle I tried the `id` you suggested in https://github.com/ioos/ioos_metrics/pull/109#issuecomment-2650988095, but that did not work. I don't recall the original page to assess the changes here. (That is the main issue with scraping.)

There are some inconsistencies with the page. This part of the text suggest 15 buoys:

![Screenshot from 2025-02-11 18-23-55](https://github.com/user-attachments/assets/8aceb17d-47c1-4192-a5b2-07cf39a4a578)

However, counting the ones in the list and in the map we have 16:

![Screenshot from 2025-02-11 18-24-42](https://github.com/user-attachments/assets/e51d6823-b92e-4bbf-a57e-9f2b1e88d69e)

and

![Screenshot from 2025-02-11 18-25-39](https://github.com/user-attachments/assets/f3cf0e83-229f-4942-9fbf-e077e25f1952)


In this new version of the code we find 16 by using the map entries. Hopefully the map won't code won't change that much and this will be a bit more robust than before.