### PR TITLE
adding a description to gts region page

### DIFF
--- a/website/templates/gts_regional_landing_page.html
+++ b/website/templates/gts_regional_landing_page.html
@@ -44,6 +44,11 @@
     <div class="mywrap">
       <h2 class="title">{{org_config.general_title}}</h2>
     </div>
+    <ul>
+      <li>The tables below summarize the messages sent to the Global Telecommunications System (GTS) from IOOS regions. </li>
+      <li>You can find the source data for all the tables and graphics presented here on the IOOS ERDDAP. </li>
+      <li>GTS datasets on IOOS ERDDAP: <a href="https://erddap.ioos.us/erddap/search/index.html?page=1&itemsPerPage=1000&searchFor=GTS">https://erddap.ioos.us/erddap/search/index.html?page=1&itemsPerPage=1000&searchFor=GTS</a></li>
+    </ul>
     <a class="longTitle">Last updated: {{configs.today}}</a>
     <div class="mywrap">
 


### PR DESCRIPTION
I wanted to include a link to the source data and some bare minimum description of the data presented in the tables